### PR TITLE
feat: change the icon loading mode

### DIFF
--- a/lib/create-append-anything/append-menu/AppendContextPadProvider.js
+++ b/lib/create-append-anything/append-menu/AppendContextPadProvider.js
@@ -51,7 +51,7 @@ AppendContextPadProvider.prototype.getContextPadEntries = function(element) {
     return {
       'append': {
         group: 'model',
-        imageUrl: appendIcon,
+        html: `<div class="entry"> ${appendIcon}</div>`,
         title: translate('Append element'),
         action: {
           click: function(event, element) {

--- a/lib/create-append-anything/create-menu/CreatePaletteProvider.js
+++ b/lib/create-append-anything/create-menu/CreatePaletteProvider.js
@@ -66,7 +66,7 @@ CreatePaletteProvider.prototype.getPaletteEntries = function(element) {
   return {
     'create': {
       group: 'create',
-      imageUrl: createIcon,
+      html: `<div class="entry"> ${createIcon}</div>`,
       title: translate('Create element'),
       action: {
         click: function(event) {

--- a/lib/icons/Icons.js
+++ b/lib/icons/Icons.js
@@ -2,8 +2,12 @@
  * To change the icons, modify the SVGs in `./resources`, execute `npx svgo -f resources --datauri enc -o dist`,
  * and then replace respective icons with the optimized data URIs in `./dist`.
  */
-const appendIcon = 'data:image/svg+xml,%3Csvg%20width%3D%2222%22%20height%3D%2222%22%20viewBox%3D%220%200%205.82%205.82%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20d%3D%22M1.3%203.4c.3%200%20.5-.2.5-.5s-.2-.4-.5-.4c-.2%200-.4.1-.4.4%200%20.3.2.5.4.5zM3%203.4c.2%200%20.4-.2.4-.5s-.2-.4-.4-.4c-.3%200-.5.1-.5.4%200%20.3.2.5.5.5zM4.6%203.4c.2%200%20.4-.2.4-.5s-.2-.4-.4-.4c-.3%200-.5.1-.5.4%200%20.3.2.5.5.5z%22%2F%3E%0A%3C%2Fsvg%3E';
-const createIcon = 'data:image/svg+xml,%3Csvg%20width%3D%2246%22%20height%3D%2246%22%20viewBox%3D%22-2%20-2%209.82%209.82%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M1.3%203.4c.3%200%20.5-.2.5-.5s-.2-.4-.5-.4c-.2%200-.4.1-.4.4%200%20.3.2.5.4.5zM3%203.4c.2%200%20.4-.2.4-.5s-.2-.4-.4-.4c-.3%200-.5.1-.5.4%200%20.3.2.5.5.5zM4.6%203.4c.2%200%20.4-.2.4-.5s-.2-.4-.4-.4c-.3%200-.5.1-.5.4%200%20.3.2.5.5.5z%22%2F%3E%0A%3C%2Fsvg%3E';
+const appendIcon = `<svg width="22" height="22" viewBox="0 0 5.82 5.82" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
+                    </svg>`;
+const createIcon = `<svg width="46" height="46" viewBox="-2 -2 9.82 9.82" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
+                    </svg>`;
 
 export {
   appendIcon,


### PR DESCRIPTION
appendIcon and createIcon icon loading mode is changed to html to facilitate css to change icon color

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
css change color
```
.djs-context-pad {
  > .group {
    .create-append-anything-append-element {
      fill: #1e80ff !important;
    }
  }
}
.djs-palette-entries {
  > .group {
    .create-append-anything-create-element {
      fill: #1e80ff !important;
    }
  }
}
```
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/62740686/234444387-03f07357-c5c8-4782-ad43-b0c2a903205c.png">
<img width="551" alt="image" src="https://user-images.githubusercontent.com/62740686/234444700-fcc35b38-f065-47c9-a9fd-0ab10c799b8d.png">

Closes #5 