### PR TITLE
fix: apply `fill=currentColor` to icons

### DIFF
--- a/lib/icons/Icons.js
+++ b/lib/icons/Icons.js
@@ -1,13 +1,9 @@
-/**
- * To change the icons, modify the SVGs in `./resources`, execute `npx svgo -f resources --datauri enc -o dist`,
- * and then replace respective icons with the optimized data URIs in `./dist`.
- */
-const appendIcon = `<svg width="22" height="22" viewBox="0 0 5.82 5.82" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
-                    </svg>`;
-const createIcon = `<svg width="46" height="46" viewBox="-2 -2 9.82 9.82" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
-                    </svg>`;
+const appendIcon = `<svg width="22" height="22" viewBox="0 0 5.82 5.82" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
+</svg>`;
+const createIcon = `<svg width="46" height="46" viewBox="-2 -2 9.82 9.82" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
+</svg>`;
 
 export {
   appendIcon,

--- a/lib/icons/resources/append.svg
+++ b/lib/icons/resources/append.svg
@@ -1,3 +1,3 @@
-<svg width="22" height="22" viewBox="0 0 5.82 5.82" xmlns="http://www.w3.org/2000/svg">
+<svg width="22" height="22" viewBox="0 0 5.82 5.82" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
   <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
 </svg>

--- a/lib/icons/resources/create.svg
+++ b/lib/icons/resources/create.svg
@@ -1,3 +1,3 @@
-<svg width="46" height="46" viewBox="-2 -2 9.82 9.82" xmlns="http://www.w3.org/2000/svg">
+<svg width="46" height="46" viewBox="-2 -2 9.82 9.82" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
   <path d="M1.3 3.4c.3 0 .5-.2.5-.5s-.2-.4-.5-.4c-.2 0-.4.1-.4.4 0 .3.2.5.4.5zM3 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5zM4.6 3.4c.2 0 .4-.2.4-.5s-.2-.4-.4-.4c-.3 0-.5.1-.5.4 0 .3.2.5.5.5z"/>
 </svg>

--- a/test/spec/element-templates/CreateAppendElementTemplates.spec.js
+++ b/test/spec/element-templates/CreateAppendElementTemplates.spec.js
@@ -17,7 +17,7 @@ import {
   CloudElementTemplatesPropertiesProviderModule as ElementTemplatesProviderModule
 } from 'bpmn-js-properties-panel';
 
-import { CreateAppendElementTemplatesModule } from 'lib/';
+import { CreateAppendElementTemplatesModule, CreateAppendAnythingModule } from 'lib/';
 
 import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
@@ -62,6 +62,7 @@ describe('<CreateAppendAnything>', function() {
         ZeebePropertiesProviderModule,
         ElementTemplatesProviderModule,
         ElementTemplateChooserModule,
+        CreateAppendAnythingModule,
         CreateAppendElementTemplatesModule
       ],
       moddleExtensions = {


### PR DESCRIPTION
Ensures that hover effects kick in:

![capture MqpQ9y_optimized](https://github.com/bpmn-io/bpmn-js-create-append-anything/assets/58601/60c71fea-b5ba-46fb-b918-fea9e7538696)
