### PR TITLE
docs: link to `bpmn-js-element-templates` as a provider source

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const modeler = new BpmnModeler({
 });
 ```
 
-This relies on `elementTemplates` to be provided via an external module, i.e. [bpmn-js-properties-panel](https://github.com/bpmn-io/bpmn-js-properties-panel).
+This relies on `elementTemplates` to be provided via an external module, i.e. [bpmn-js-element-templates](https://github.com/bpmn-io/bpmn-js-element-templates).
 
 
 ## Run locally


### PR DESCRIPTION
This supports our element template liberation initiative.