### PR TITLE
fix(append-menu): use rule to decide whether to show context pad entry

### DIFF
--- a/lib/create-append-anything/append-menu/AppendContextPadProvider.js
+++ b/lib/create-append-anything/append-menu/AppendContextPadProvider.js
@@ -10,12 +10,13 @@ import {
 /**
  * A provider for append context pad button
  */
-export default function AppendContextPadProvider(contextPad, popupMenu, translate, canvas) {
+export default function AppendContextPadProvider(contextPad, popupMenu, translate, canvas, rules) {
 
   this._contextPad = contextPad;
   this._popupMenu = popupMenu;
   this._translate = translate;
   this._canvas = canvas;
+  this._rules = rules;
 
   this.register();
 }
@@ -24,7 +25,8 @@ AppendContextPadProvider.$inject = [
   'contextPad',
   'popupMenu',
   'translate',
-  'canvas'
+  'canvas',
+  'rules'
 ];
 
 /**
@@ -43,9 +45,10 @@ AppendContextPadProvider.prototype.register = function() {
 AppendContextPadProvider.prototype.getContextPadEntries = function(element) {
   const popupMenu = this._popupMenu;
   const translate = this._translate;
+  const rules = this._rules;
   const getAppendMenuPosition = this._getAppendMenuPosition.bind(this);
 
-  if (!popupMenu.isEmpty(element, 'bpmn-append')) {
+  if (rules.allowed('shape.append', { element })) {
 
     // append menu entry
     return {


### PR DESCRIPTION
* rule is already being used to decide whether to add popup menu entries
* prevents context pad entry to be shown because other providers added popup menu entries

Related to https://github.com/camunda/web-modeler/issues/8482

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
