### PR TITLE
fix: remove dependency on deprecated `contextPad#getPad`

### DIFF
--- a/lib/create-append-anything/append-menu/AppendContextPadProvider.js
+++ b/lib/create-append-anything/append-menu/AppendContextPadProvider.js
@@ -82,11 +82,9 @@ AppendContextPadProvider.prototype.getContextPadEntries = function(element) {
  * @returns {Object}
  */
 AppendContextPadProvider.prototype._getAppendMenuPosition = function(element) {
-  const contextPad = this._contextPad;
-
   const X_OFFSET = 5;
 
-  const pad = contextPad.getPad(element).html;
+  const pad = this._canvas.getContainer().querySelector('.djs-context-pad');
 
   const padRect = pad.getBoundingClientRect();
 

--- a/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
@@ -41,7 +41,7 @@ describe('features/create-append-anything - append menu provider', function() {
       // when
       contextPad.trigger('click', padEvent('append'));
 
-      const padMenuRect = contextPad.getPad(element).html.getBoundingClientRect();
+      const padMenuRect = getPad().getBoundingClientRect();
       const replaceMenuRect = getPopupMenu().getBoundingClientRect();
 
       // then
@@ -64,7 +64,7 @@ describe('features/create-append-anything - append menu provider', function() {
         // when
         contextPad.open(element);
 
-        const padNode = contextPad.getPad(element).html;
+        const padNode = getPad();
 
         // then
         expect(padEntry(padNode, 'append')).not.to.exist;
@@ -86,7 +86,7 @@ describe('features/create-append-anything - append menu provider', function() {
         // when
         contextPad.open(element);
 
-        const padNode = contextPad.getPad(element).html;
+        const padNode = getPad();
 
         // then
         expect(padEntry(padNode, 'append')).to.exist;
@@ -103,17 +103,19 @@ function padEntry(element, name) {
 }
 
 function padEvent(entry) {
+  const target = padEntry(getPad(), entry);
 
-  return getBpmnJS().invoke(function(overlays) {
+  return {
+    target: target,
+    preventDefault: function() {},
+    clientX: 100,
+    clientY: 100
+  };
+}
 
-    const target = padEntry(overlays._overlayRoot, entry);
-
-    return {
-      target: target,
-      preventDefault: function() {},
-      clientX: 100,
-      clientY: 100
-    };
+function getPad() {
+  return getBpmnJS().invoke(function(canvas) {
+    return canvas.getContainer().querySelector('.djs-context-pad');
   });
 }
 


### PR DESCRIPTION
Closes #34

### Proposed Changes

This removes dependency on deprecated method, and also adjusts to not rely on context pad being an overlay.
Solution is based on https://github.com/bpmn-io/diagram-js/pull/888#discussion_r1578010293

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
