### PR TITLE
Provide element template `keywords` to popup-menu search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to [bpmn-js-create-append-anything](https://github.com/bpmn-
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.0.0
+
+* `FEAT`: source element template `keywords` during search ([#50](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/50))
+* `DEPS`: depend on `diagram-js>=15.3.0` ([#50](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/50))
+
+### Breaking Changes
+
+* Require `diagram-js>=15.3.0` as a peer dependency ([#50](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/50))
+
 ## 0.6.0
 
 * `FEAT`: add ad-hoc subprocess entry ([#47](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/47))

--- a/lib/element-templates/append-menu/ElementTemplatesAppendProvider.js
+++ b/lib/element-templates/append-menu/ElementTemplatesAppendProvider.js
@@ -74,6 +74,7 @@ ElementTemplatesAppendProvider.prototype.getTemplateEntries = function(element, 
     const {
       icon = {},
       category,
+      keywords = [],
     } = template;
 
     const entryId = `append.template-${template.id}`;
@@ -87,6 +88,7 @@ ElementTemplatesAppendProvider.prototype.getTemplateEntries = function(element, 
       label: template.name,
       description: template.description,
       documentationRef: template.documentationRef,
+      search: keywords,
       imageUrl: icon.contents,
       group: category || defaultGroup,
       action: this._getEntryAction(element, template)

--- a/lib/element-templates/create-menu/ElementTemplatesCreateProvider.js
+++ b/lib/element-templates/create-menu/ElementTemplatesCreateProvider.js
@@ -65,6 +65,7 @@ ElementTemplatesCreateProvider.prototype.getTemplateEntries = function() {
     const {
       icon = {},
       category,
+      keywords = [],
     } = template;
 
     const entryId = `create.template-${template.id}`;
@@ -80,6 +81,7 @@ ElementTemplatesCreateProvider.prototype.getTemplateEntries = function() {
       documentationRef: template.documentationRef,
       imageUrl: icon.contents,
       group: category || defaultGroup,
+      search: keywords,
       action: {
         click: this._getEntryAction(template),
         dragstart: this._getEntryAction(template)

--- a/lib/element-templates/replace-menu/ElementTemplatesReplaceProvider.js
+++ b/lib/element-templates/replace-menu/ElementTemplatesReplaceProvider.js
@@ -70,6 +70,7 @@ ElementTemplatesReplaceProvider.prototype.getTemplateEntries = function(element)
     const {
       icon = {},
       category,
+      keywords = [],
     } = template;
 
     const entryId = `replace.template-${template.id}`;
@@ -84,6 +85,7 @@ ElementTemplatesReplaceProvider.prototype.getTemplateEntries = function(element)
       description: template.description,
       documentationRef: template.documentationRef,
       imageUrl: icon.contents,
+      search: keywords,
       group: category || defaultGroup,
       action: () => {
         this._elementTemplates.applyTemplate(element, template);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,15 @@
       "name": "bpmn-js-create-append-anything",
       "version": "0.6.0",
       "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/element-template-chooser": "^1.0.0"
-      },
       "devDependencies": {
+        "@bpmn-io/element-template-chooser": "^2.0.0",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@testing-library/preact": "^3.2.3",
         "babel-loader": "^10.0.0",
         "babel-plugin-istanbul": "^7.0.0",
-        "bpmn-js": "^18.2.0",
+        "bpmn-js": "^18.6.0",
         "bpmn-js-element-templates": "^2.5.1",
         "bpmn-js-properties-panel": "^5.31.1",
         "cross-env": "^7.0.3",
@@ -412,28 +410,32 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "dev": true,
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
       }
     },
     "node_modules/@bpmn-io/element-template-chooser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-chooser/-/element-template-chooser-1.0.0.tgz",
-      "integrity": "sha512-jSzvoWwYiTpsR7X/+nhao8e8jfveTPLeT3cUUJYhcztLysJaJo+5VXX+QbzH4eFOCnqaoIz6ehbd8px4EjVYnA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-chooser/-/element-template-chooser-2.0.0.tgz",
+      "integrity": "sha512-SUQgAzkCA3lBsV6MYVTFlZSOZJv5m4iZ3f4IN13azppYh6rU0eNXGUy8K0jUkiNx3K2Umwq2Hd7R9IKZ9Ms/jQ==",
+      "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "bpmn-js": ">= 11",
-        "diagram-js": ">= 11.3.0"
+        "diagram-js": ">= 15.3.0"
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.2.tgz",
-      "integrity": "sha512-Gr6pNSoFif2Sgd01+NdPVVLGrz4R/AICHbK29zBcF849RDH+iLq7qAUhbT8MwwUKOs9WHztXoDTEiKbF85lx5g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.3.tgz",
+      "integrity": "sha512-Q39lxuUA1T7pCkKiy40EAncr7MLVITq/P1MRDPHpFUz2S1Yvt5aZ4IdyKBpATlffcF5s6UfnRY7bq8qE+e2byw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.22.2",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.3",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -515,13 +517,15 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.1.tgz",
       "integrity": "sha512-gwQJHUYx1FrIJCgJISx2cpqTJYgnsqrJ6dpPX/R0p6ELyK6u4rHAi/m9QS1O4F6ua7dBlFFFOOtuIAbo5mAfAg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.2.tgz",
-      "integrity": "sha512-qKUa64twO5Ewh6rN+z0n1cdTweuKYuwPCZH6VL7knsdfSYe4PBLnx8FwTXS6Hc5LZCP60rp+XXgQ5puQZfqlNQ==",
-      "dev": true
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.3.tgz",
+      "integrity": "sha512-22D9ZAkBounIpQ0DKQ5lmkGGE7LZM7WCwLBez8AT0hGTHVve5egUCrh3f7QIm5DkdIHxyWdibD0zRIWUhDBrYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.11.1",
@@ -2414,12 +2418,14 @@
       "dev": true
     },
     "node_modules/bpmn-js": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.2.0.tgz",
-      "integrity": "sha512-2wdOUe2WjR+hvDsHorzNyIe52Ep8l1a79FJPQsss0fm2Jrjx/Sf9hRs+C3cKIbogBTZPQkmuS/QoCFjniMevzg==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.0.tgz",
+      "integrity": "sha512-GBUUpnKdrbD1p6Q/O/GLIoMonWxb6yRsDNDG8YdX2Vl9MIV7Gim+5zKKRDRCMZcCbTLrdUrCWb2OOfnywU/8Ew==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.2.4",
+        "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -2432,13 +2438,14 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.5.1.tgz",
-      "integrity": "sha512-w08tAW0XQ+N1g4V7F/QmrrzDq88YjNao69nwbwyO83oTG2pB32Y3aDXDXJqvJJnNUnsjREKVXllNcZioGP1Dsg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.5.3.tgz",
+      "integrity": "sha512-r3JUZHj1NOS0JDVENBYKIXv9VdYyhp97IM3AVnQzE/JwGOsaLBiwvp88C/0qsB2dhfyZ6hd/uF5FHKu95CIwJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.3.2",
-        "@bpmn-io/extract-process-variables": "^1.0.0",
+        "@bpmn-io/element-templates-validator": "^2.3.3",
+        "@bpmn-io/extract-process-variables": "^1.0.1",
         "bpmnlint": "^11.0.0",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
@@ -2473,10 +2480,11 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.31.1.tgz",
-      "integrity": "sha512-DH+IYngB0SVGh5yqDhKoFQMIR3sgnQgh8NFua0OmjKiwyxIaT/nzrPmuY/QEGhS0YbmRPfNIH0xVlFJwGR6jeA==",
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.35.0.tgz",
+      "integrity": "sha512-Oigs0Yik/rYZhIwUSaNSINpidSWXXuuKxQaRTt804Nbpz6s/mIwEb6poxk/XDeK5iXwIkB7sZkh1VvOLBOAwPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^1.0.0",
         "array-move": "^4.0.0",
@@ -2498,6 +2506,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
       "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.2.1",
         "moddle": "^7.0.0",
@@ -2868,6 +2877,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2921,7 +2931,8 @@
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3331,9 +3342,11 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
-      "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
+      "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -3353,6 +3366,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
       "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.2.1"
@@ -3368,6 +3382,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
       "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -3403,7 +3418,8 @@
     "node_modules/domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
+      "dev": true
     },
     "node_modules/downloadjs": {
       "version": "1.4.7",
@@ -4929,7 +4945,8 @@
     "node_modules/htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5017,7 +5034,8 @@
     "node_modules/ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
+      "dev": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5102,7 +5120,8 @@
     "node_modules/inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -5811,7 +5830,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
       "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6430,12 +6450,14 @@
     "node_modules/min-dash": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
+      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ==",
+      "dev": true
     },
     "node_modules/min-dom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -6666,6 +6688,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
       "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.2.1"
       }
@@ -6674,6 +6697,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
       "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "saxen": "^10.0.0"
@@ -6906,6 +6930,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7152,6 +7177,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
       "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.20"
       }
@@ -7257,6 +7283,7 @@
       "version": "10.13.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
       "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7855,6 +7882,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
       "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
+      "dev": true,
       "engines": {
         "node": ">= 18"
       }
@@ -8537,7 +8565,8 @@
     "node_modules/tiny-svg": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
+      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ==",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -9553,25 +9582,27 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "dev": true,
       "requires": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
       }
     },
     "@bpmn-io/element-template-chooser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-chooser/-/element-template-chooser-1.0.0.tgz",
-      "integrity": "sha512-jSzvoWwYiTpsR7X/+nhao8e8jfveTPLeT3cUUJYhcztLysJaJo+5VXX+QbzH4eFOCnqaoIz6ehbd8px4EjVYnA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-chooser/-/element-template-chooser-2.0.0.tgz",
+      "integrity": "sha512-SUQgAzkCA3lBsV6MYVTFlZSOZJv5m4iZ3f4IN13azppYh6rU0eNXGUy8K0jUkiNx3K2Umwq2Hd7R9IKZ9Ms/jQ==",
+      "dev": true,
       "requires": {}
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.2.tgz",
-      "integrity": "sha512-Gr6pNSoFif2Sgd01+NdPVVLGrz4R/AICHbK29zBcF849RDH+iLq7qAUhbT8MwwUKOs9WHztXoDTEiKbF85lx5g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.3.tgz",
+      "integrity": "sha512-Q39lxuUA1T7pCkKiy40EAncr7MLVITq/P1MRDPHpFUz2S1Yvt5aZ4IdyKBpATlffcF5s6UfnRY7bq8qE+e2byw==",
       "dev": true,
       "requires": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.22.2",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.3",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -9647,9 +9678,9 @@
       "dev": true
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.2.tgz",
-      "integrity": "sha512-qKUa64twO5Ewh6rN+z0n1cdTweuKYuwPCZH6VL7knsdfSYe4PBLnx8FwTXS6Hc5LZCP60rp+XXgQ5puQZfqlNQ==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.3.tgz",
+      "integrity": "sha512-22D9ZAkBounIpQ0DKQ5lmkGGE7LZM7WCwLBez8AT0hGTHVve5egUCrh3f7QIm5DkdIHxyWdibD0zRIWUhDBrYg==",
       "dev": true
     },
     "@codemirror/autocomplete": {
@@ -11027,12 +11058,13 @@
       }
     },
     "bpmn-js": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.2.0.tgz",
-      "integrity": "sha512-2wdOUe2WjR+hvDsHorzNyIe52Ep8l1a79FJPQsss0fm2Jrjx/Sf9hRs+C3cKIbogBTZPQkmuS/QoCFjniMevzg==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.0.tgz",
+      "integrity": "sha512-GBUUpnKdrbD1p6Q/O/GLIoMonWxb6yRsDNDG8YdX2Vl9MIV7Gim+5zKKRDRCMZcCbTLrdUrCWb2OOfnywU/8Ew==",
+      "dev": true,
       "requires": {
         "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.2.4",
+        "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -11042,13 +11074,13 @@
       }
     },
     "bpmn-js-element-templates": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.5.1.tgz",
-      "integrity": "sha512-w08tAW0XQ+N1g4V7F/QmrrzDq88YjNao69nwbwyO83oTG2pB32Y3aDXDXJqvJJnNUnsjREKVXllNcZioGP1Dsg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.5.3.tgz",
+      "integrity": "sha512-r3JUZHj1NOS0JDVENBYKIXv9VdYyhp97IM3AVnQzE/JwGOsaLBiwvp88C/0qsB2dhfyZ6hd/uF5FHKu95CIwJw==",
       "dev": true,
       "requires": {
-        "@bpmn-io/element-templates-validator": "^2.3.2",
-        "@bpmn-io/extract-process-variables": "^1.0.0",
+        "@bpmn-io/element-templates-validator": "^2.3.3",
+        "@bpmn-io/extract-process-variables": "^1.0.1",
         "bpmnlint": "^11.0.0",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
@@ -11069,9 +11101,9 @@
       }
     },
     "bpmn-js-properties-panel": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.31.1.tgz",
-      "integrity": "sha512-DH+IYngB0SVGh5yqDhKoFQMIR3sgnQgh8NFua0OmjKiwyxIaT/nzrPmuY/QEGhS0YbmRPfNIH0xVlFJwGR6jeA==",
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.35.0.tgz",
+      "integrity": "sha512-Oigs0Yik/rYZhIwUSaNSINpidSWXXuuKxQaRTt804Nbpz6s/mIwEb6poxk/XDeK5iXwIkB7sZkh1VvOLBOAwPw==",
       "dev": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^1.0.0",
@@ -11085,6 +11117,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
       "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
+      "dev": true,
       "requires": {
         "min-dash": "^4.2.1",
         "moddle": "^7.0.0",
@@ -11335,7 +11368,8 @@
     "clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -11379,7 +11413,8 @@
     "component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11677,9 +11712,10 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
-      "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
+      "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
+      "dev": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -11696,6 +11732,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
       "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
+      "dev": true,
       "requires": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.2.1"
@@ -11704,7 +11741,8 @@
     "didi": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
-      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w=="
+      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
+      "dev": true
     },
     "diff": {
       "version": "5.2.0",
@@ -11733,7 +11771,8 @@
     "domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
+      "dev": true
     },
     "downloadjs": {
       "version": "1.4.7",
@@ -12842,7 +12881,8 @@
     "htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -12914,7 +12954,8 @@
     "ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -12971,7 +13012,8 @@
     "inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -13948,12 +13990,14 @@
     "min-dash": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
+      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ==",
+      "dev": true
     },
     "min-dom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "dev": true,
       "requires": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -14121,6 +14165,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
       "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
+      "dev": true,
       "requires": {
         "min-dash": "^4.2.1"
       }
@@ -14129,6 +14174,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
       "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
+      "dev": true,
       "requires": {
         "min-dash": "^4.0.0",
         "saxen": "^10.0.0"
@@ -14289,7 +14335,8 @@
     "object-refs": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
-      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ=="
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.5",
@@ -14466,7 +14513,8 @@
     "path-intersection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
-      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA=="
+      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -14538,7 +14586,8 @@
     "preact": {
       "version": "10.13.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
-      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ=="
+      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
+      "dev": true
     },
     "preact-markup": {
       "version": "2.1.1",
@@ -14977,7 +15026,8 @@
     "saxen": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g=="
+      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.1",
@@ -15478,7 +15528,8 @@
     "tiny-svg": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
+      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ==",
+      "dev": true
     },
     "tmp": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,9 @@
         "sinon-chai": "^3.7.0",
         "webpack": "^5.96.1",
         "zeebe-bpmn-moddle": "^1.9.0"
+      },
+      "peerDependencies": {
+        "diagram-js": ">= 15.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -410,7 +413,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "dev": true,
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -2877,7 +2879,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2931,8 +2932,7 @@
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3345,7 +3345,6 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
       "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
@@ -3382,7 +3381,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
       "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
-      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -3418,8 +3416,7 @@
     "node_modules/domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
     },
     "node_modules/downloadjs": {
       "version": "1.4.7",
@@ -4945,8 +4942,7 @@
     "node_modules/htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5120,8 +5116,7 @@
     "node_modules/inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
-      "dev": true
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -6450,14 +6445,12 @@
     "node_modules/min-dash": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ==",
-      "dev": true
+      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
     },
     "node_modules/min-dom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
-      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -6930,7 +6923,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7177,7 +7169,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
       "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
-      "dev": true,
       "engines": {
         "node": ">= 14.20"
       }
@@ -7283,7 +7274,6 @@
       "version": "10.13.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
       "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8565,8 +8555,7 @@
     "node_modules/tiny-svg": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ==",
-      "dev": true
+      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -9582,7 +9571,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "dev": true,
       "requires": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -11368,8 +11356,7 @@
     "clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -11413,8 +11400,7 @@
     "component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11715,7 +11701,6 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
       "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
-      "dev": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -11741,8 +11726,7 @@
     "didi": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
-      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
-      "dev": true
+      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w=="
     },
     "diff": {
       "version": "5.2.0",
@@ -11771,8 +11755,7 @@
     "domify": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
-      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==",
-      "dev": true
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
     },
     "downloadjs": {
       "version": "1.4.7",
@@ -12881,8 +12864,7 @@
     "htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -13012,8 +12994,7 @@
     "inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
-      "dev": true
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -13990,14 +13971,12 @@
     "min-dash": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.2.tgz",
-      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ==",
-      "dev": true
+      "integrity": "sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ=="
     },
     "min-dom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
-      "dev": true,
       "requires": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -14335,8 +14314,7 @@
     "object-refs": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
-      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "dev": true
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ=="
     },
     "object.assign": {
       "version": "4.1.5",
@@ -14513,8 +14491,7 @@
     "path-intersection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
-      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
-      "dev": true
+      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -14586,8 +14563,7 @@
     "preact": {
       "version": "10.13.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
-      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
-      "dev": true
+      "integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ=="
     },
     "preact-markup": {
       "version": "2.1.1",
@@ -15528,8 +15504,7 @@
     "tiny-svg": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ==",
-      "dev": true
+      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "dist"
   ],
   "module": "dist/index.es.js",
+  "peerDependencies": {
+    "diagram-js": ">= 15.3.0"
+  },
   "devDependencies": {
     "@bpmn-io/element-template-chooser": "^2.0.0",
     "@rollup/plugin-commonjs": "^28.0.1",

--- a/package.json
+++ b/package.json
@@ -42,13 +42,14 @@
   ],
   "module": "dist/index.es.js",
   "devDependencies": {
+    "@bpmn-io/element-template-chooser": "^2.0.0",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@testing-library/preact": "^3.2.3",
     "babel-loader": "^10.0.0",
     "babel-plugin-istanbul": "^7.0.0",
-    "bpmn-js": "^18.2.0",
+    "bpmn-js": "^18.6.0",
     "bpmn-js-element-templates": "^2.5.1",
     "bpmn-js-properties-panel": "^5.31.1",
     "cross-env": "^7.0.3",
@@ -74,8 +75,5 @@
     "sinon-chai": "^3.7.0",
     "webpack": "^5.96.1",
     "zeebe-bpmn-moddle": "^1.9.0"
-  },
-  "dependencies": {
-    "@bpmn-io/element-template-chooser": "^1.0.0"
   }
 }

--- a/test/fixtures/element-templates.json
+++ b/test/fixtures/element-templates.json
@@ -20,7 +20,9 @@
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Participant Template",
     "id": "example.ParticipantTemplate",
-    "appliesTo": ["bpmn:Participant"],
+    "appliesTo": [
+      "bpmn:Participant"
+    ],
     "properties": [
       {
         "binding": {
@@ -34,7 +36,9 @@
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Start Event Template",
     "id": "example.StartEventTemplate",
-    "appliesTo": ["bpmn:StartEvent"],
+    "appliesTo": [
+      "bpmn:StartEvent"
+    ],
     "properties": [
       {
         "binding": {
@@ -59,6 +63,19 @@
           "name": "conditionExpression"
         }
       }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Keywords Template",
+    "id": "example.KeywordsTemplate",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [],
+    "keywords": [
+      "first keyword",
+      "another keyword"
     ]
   }
 ]

--- a/test/spec/element-templates/append-menu/ElementTemplatesAppendProvider.spec.js
+++ b/test/spec/element-templates/append-menu/ElementTemplatesAppendProvider.spec.js
@@ -209,6 +209,26 @@ describe('<ElementTemplatesAppendProvider>', function() {
 
   });
 
+
+  describe('search', function() {
+
+    it('should be searchable by keywords', inject(function(elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      openPopup(task);
+
+      // when
+      const entries = getEntries();
+      const entry = entries['append.template-example.KeywordsTemplate'];
+
+      // then
+      expect(entry?.search).to.be.eql([ 'first keyword', 'another keyword' ]);
+    }));
+
+  });
+
 });
 
 

--- a/test/spec/element-templates/create-menu/ElementTemplatesCreateProvider.spec.js
+++ b/test/spec/element-templates/create-menu/ElementTemplatesCreateProvider.spec.js
@@ -135,6 +135,25 @@ describe('<ElementTemplatesCreateProviderSpec>', function() {
 
   });
 
+  describe('search', function() {
+
+    it('should be searchable by keywords', inject(function(canvas) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // when
+      openPopup(rootElement);
+
+      const entries = getEntries();
+      const entry = entries['create.template-example.KeywordsTemplate'];
+
+      // then
+      expect(entry?.search).to.be.eql([ 'first keyword', 'another keyword' ]);
+    }));
+
+  });
+
 });
 
 

--- a/test/spec/element-templates/replace-menu/ElementTemplatesReplaceProvider.element-templates.json
+++ b/test/spec/element-templates/replace-menu/ElementTemplatesReplaceProvider.element-templates.json
@@ -783,5 +783,18 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Keywords Template",
+    "id": "example.KeywordsTemplate",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [],
+    "keywords": [
+      "first keyword",
+      "another keyword"
+    ]
   }
 ]

--- a/test/spec/element-templates/replace-menu/ElementTemplatesReplaceProvider.spec.js
+++ b/test/spec/element-templates/replace-menu/ElementTemplatesReplaceProvider.spec.js
@@ -65,7 +65,7 @@ describe('<ElementTemplatesReplaceProvider>', function() {
 
       // then
       const entries = getTemplateEntries();
-      expect(entries).to.have.length(6);
+      expect(entries).to.have.length(7);
     }));
 
 
@@ -79,7 +79,7 @@ describe('<ElementTemplatesReplaceProvider>', function() {
 
       // then
       const entries = getTemplateEntries();
-      expect(entries).to.have.length(5);
+      expect(entries).to.have.length(6);
     }));
 
 
@@ -96,7 +96,7 @@ describe('<ElementTemplatesReplaceProvider>', function() {
 
       // then
       const entries = getTemplateEntries();
-      expect(entries).to.have.length(5);
+      expect(entries).to.have.length(6);
     }));
 
 
@@ -271,6 +271,26 @@ describe('<ElementTemplatesReplaceProvider>', function() {
 
       // then
       expect(isTemplateApplied(task, template)).to.be.true;
+    }));
+
+  });
+
+
+  describe('search', function() {
+
+    it('should be searchable by keywords', inject(function(elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      openPopup(task);
+
+      const entries = getEntries();
+      const entry = entries['replace.template-example.KeywordsTemplate'];
+
+      // then
+      expect(entry?.search).to.be.eql([ 'first keyword', 'another keyword' ]);
     }));
 
   });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4853

Depends on https://github.com/bpmn-io/diagram-js/pull/970

### Proposed Changes

To make use of the new keyword property it has to be forwarded to the popup menu as an entry. This PR just adds that property to the according provider.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Try out

`npm run start`

try to create, append, or replace an element. you should be able to find templates also via their keyword. for example "another keyword" for the keyword template

<img width="369" alt="image" src="https://github.com/user-attachments/assets/58d1293f-cef7-4518-af82-7181eeea04ce" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
