### PR TITLE
chore: feature { category, icon } in our `start:templates` script

### DIFF
--- a/test/fixtures/element-templates.json
+++ b/test/fixtures/element-templates.json
@@ -20,6 +20,13 @@
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Participant Template",
     "id": "example.ParticipantTemplate",
+    "category": {
+      "id": "process-templates",
+      "name": "Process Templates"
+    },
+    "icon": {
+      "contents": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2049.363%2027.445%22%3E%3Cpath%20d%3D%22M1.818%2012.82h46.363v24.445H1.818z%22%20style%3D%22fill%3A%23fff%3Bstroke%3A%2310ad73%3Bstroke-width%3A3%3Bstroke-linecap%3Around%3Bstroke-linejoin%3Amiter%3Bstroke-dasharray%3Anone%22%20transform%3D%22translate(-.318%20-11.32)%22%2F%3E%3Cpath%20d%3D%22m10.63%2018.247%206.684%206.684-6.684%206.683%22%20style%3D%22fill%3Anone%3Bstroke%3A%2310ad73%3Bstroke-width%3A1.7135%3Bstroke-linecap%3Around%3Bstroke-linejoin%3Around%22%20transform%3D%22translate(4.551%20-11.32)%22%2F%3E%3Cpath%20d%3D%22m16.788%2017.995%206.684%206.684-6.684%206.684%22%20style%3D%22fill%3Anone%3Bstroke%3A%2310ad73%3Bstroke-width%3A1.7135%3Bstroke-linecap%3Around%3Bstroke-linejoin%3Around%22%20transform%3D%22translate(4.551%20-11.32)%22%2F%3E%3Cpath%20d%3D%22m22.947%2017.975%206.683%206.684-6.683%206.683%22%20style%3D%22fill%3Anone%3Bstroke%3A%2310ad73%3Bstroke-width%3A1.7135%3Bstroke-linecap%3Around%3Bstroke-linejoin%3Around%22%20transform%3D%22translate(4.551%20-11.32)%22%2F%3E%3C%2Fsvg%3E"
+    },
     "appliesTo": [
       "bpmn:Participant"
     ],
@@ -36,6 +43,13 @@
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Start Event Template",
     "id": "example.StartEventTemplate",
+    "category": {
+      "id": "events",
+      "name": "Events"
+    },
+    "icon": {
+      "contents": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2049.388%2049.388%22%3E%3Ccircle%20cx%3D%2224.999%22%20cy%3D%2225.066%22%20r%3D%2223.233%22%20style%3D%22fill%3A%23fff%3Bstroke%3A%2310ad73%3Bstroke-width%3A2.9216%3Bstroke-linecap%3Around%3Bstroke-linejoin%3Around%3Bstroke-dasharray%3Anone%22%20transform%3D%22translate(-.306%20-.372)%22%2F%3E%3C%2Fsvg%3E"
+    },
     "appliesTo": [
       "bpmn:StartEvent"
     ],
@@ -69,6 +83,13 @@
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Keywords Template",
     "id": "example.KeywordsTemplate",
+    "icon": {
+      "contents": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2050%2050%22%3E%3Ctext%20xml%3Aspace%3D%22preserve%22%20x%3D%223.615%22%20y%3D%2229.833%22%20style%3D%22font-style%3Anormal%3Bfont-variant%3Anormal%3Bfont-weight%3A400%3Bfont-stretch%3Anormal%3Bfont-size%3A17.6087px%3Bline-height%3A1.25%3Bfont-family%3Amonospace%3Bfill%3A%2310ad73%3Bfill-opacity%3A1%3Bstroke%3Anone%3Bstroke-width%3A.440217%3Bstroke-opacity%3A1%22%3E%3Ctspan%20x%3D%223.615%22%20y%3D%2229.833%22%20style%3D%22font-style%3Anormal%3Bfont-variant%3Anormal%3Bfont-weight%3A400%3Bfont-stretch%3Anormal%3Bfont-family%3Amonospace%3Bfill%3A%2310ad73%3Bfill-opacity%3A1%3Bstroke%3Anone%3Bstroke-width%3A.440217%3Bstroke-opacity%3A1%22%3E%23abc%3C%2Ftspan%3E%3C%2Ftext%3E%3C%2Fsvg%3E"
+    },
+    "category": {
+      "id": "other-items",
+      "name": "Other items"
+    },
     "appliesTo": [
       "bpmn:Task"
     ],


### PR DESCRIPTION
### Proposed Changes

Ensures our element templates examples meaningfully reflect used features:

* add `category = { name, id }`
* add `icon = { contents }`

Try out via `npm run start:templates`:

![capture kqKLDw_optimized](https://github.com/user-attachments/assets/8b8991a2-504b-479b-966d-c51753505e1d)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->


---

Related to https://github.com/bpmn-io/element-templates/issues/8