### PR TITLE
Add non-interrupting start events to the create menu

### DIFF
--- a/lib/util/CreateOptionsUtil.js
+++ b/lib/util/CreateOptionsUtil.js
@@ -102,6 +102,59 @@ export const TYPED_START_EVENTS = [
   }
 ].map(option => ({ ...option, group: EVENT_GROUP }));
 
+export const TYPED_NON_INTERRUPTING_START_EVENTS = [
+  {
+    label: 'Message start event (non-interrupting)',
+    actionName: 'replace-with-non-interrupting-message-start',
+    className: 'bpmn-icon-start-event-non-interrupting-message',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      isInterrupting: false
+    }
+  },
+  {
+    label: 'Timer start event (non-interrupting)',
+    actionName: 'replace-with-non-interrupting-timer-start',
+    className: 'bpmn-icon-start-event-non-interrupting-timer',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      isInterrupting: false
+    }
+  },
+  {
+    label: 'Conditional start event (non-interrupting)',
+    actionName: 'replace-with-non-interrupting-conditional-start',
+    className: 'bpmn-icon-start-event-non-interrupting-condition',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      isInterrupting: false
+    }
+  },
+  {
+    label: 'Signal start event (non-interrupting)',
+    actionName: 'replace-with-non-interrupting-signal-start',
+    className: 'bpmn-icon-start-event-non-interrupting-signal',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      isInterrupting: false
+    }
+  },
+  {
+    label: 'Escalation start event (non-interrupting)',
+    actionName: 'replace-with-non-interrupting-escalation-start',
+    className: 'bpmn-icon-start-event-non-interrupting-escalation',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      isInterrupting: false
+    }
+  }
+].map(option => ({ ...option, group: EVENT_GROUP, rank: -1 }));
+
 export const TYPED_INTERMEDIATE_EVENT = [
   {
     label: 'Message intermediate catch event',
@@ -629,6 +682,7 @@ export const CREATE_OPTIONS = [
   ...SUBPROCESS,
   ...NONE_EVENTS,
   ...TYPED_START_EVENTS,
+  ...TYPED_NON_INTERRUPTING_START_EVENTS,
   ...TYPED_INTERMEDIATE_EVENT,
   ...TYPED_END_EVENT,
   ...TYPED_BOUNDARY_EVENT,


### PR DESCRIPTION
Closes https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/4

### Proposed Changes

Add entries for non-interrupting (typed) StartEvents.

### try out 



```
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#non-interrupting-start-events
```


<img width="579" alt="image" src="https://github.com/user-attachments/assets/21802d57-3add-4722-bacc-98daa6ac5e08" />

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
