### PR TITLE
fix(element-templates): trigger create mode if auto place not possible

### DIFF
--- a/lib/element-templates/append-menu/ElementTemplatesAppendProvider.js
+++ b/lib/element-templates/append-menu/ElementTemplatesAppendProvider.js
@@ -141,23 +141,45 @@ ElementTemplatesAppendProvider.prototype._filterTemplates = function(templates) 
  * @returns {Object}
  */
 ElementTemplatesAppendProvider.prototype._getEntryAction = function(element, template) {
-  return {
+  const autoPlaceElement = () => {
+    const newElement = this._elementTemplates.createElement(template);
 
-    click: () => {
-      const newElement = this._elementTemplates.createElement(template);
-      this._autoPlace.append(element, newElement);
-    },
+    this._autoPlace.append(element, newElement);
+  };
 
-    dragstart: (event) => {
-      const newElement = this._elementTemplates.createElement(template);
+  const manualPlaceElement = (event) => {
+    const newElement = this._elementTemplates.createElement(template);
 
-      if (event instanceof KeyboardEvent) {
-        event = this._mouse.getLastMoveEvent();
-      }
-
-      this._create.start(event, newElement, {
-        source: element
-      });
+    if (event instanceof KeyboardEvent) {
+      event = this._mouse.getLastMoveEvent();
     }
+
+    return this._create.start(event, newElement, {
+      source: element
+    });
+  };
+
+  return {
+    click: canAutoPlaceElement(template) ? autoPlaceElement : manualPlaceElement,
+    dragstart: manualPlaceElement
   };
 };
+
+function canAutoPlaceElement(elementTemplate) {
+  const {
+    appliesTo = [],
+    elementType = {}
+  } = elementTemplate;
+
+  const type = elementType.value || appliesTo[0];
+
+  if (type === 'bpmn:BoundaryEvent') {
+    return false;
+  }
+
+  if (type === 'bpmn:IntermediateCatchEvent' && elementType.eventDefinition === 'bpmn:LinkEventDefinition') {
+    return false;
+  }
+
+  return true;
+}

--- a/test/fixtures/element-templates.json
+++ b/test/fixtures/element-templates.json
@@ -11,7 +11,7 @@
         "type": "Boolean",
         "binding": {
           "type": "property",
-          "name": "customProperty"
+          "name": "foo"
         }
       }
     ]
@@ -34,7 +34,7 @@
       {
         "binding": {
           "type": "property",
-          "name": "someProp"
+          "name": "foo"
         }
       }
     ]
@@ -57,7 +57,7 @@
       {
         "binding": {
           "type": "property",
-          "name": "someProp"
+          "name": "foo"
         }
       }
     ]
@@ -97,6 +97,46 @@
     "keywords": [
       "first keyword",
       "another keyword"
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Message Boundary Event Template",
+    "id": "example.MessageBoundaryEventTemplate",
+    "appliesTo": [
+      "bpmn:BoundaryEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:BoundaryEvent",
+      "eventDefinition": "bpmn:MessageEventDefinition"
+    },
+    "properties": [
+      {
+        "binding": {
+          "type": "property",
+          "name": "foo"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Link Intermediate Catch Event Template",
+    "id": "example.LinkIntermediateCatchEventTemplate",
+    "appliesTo": [
+      "bpmn:IntermediateCatchEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:IntermediateCatchEvent",
+      "eventDefinition": "bpmn:LinkEventDefinition"
+    },
+    "properties": [
+      {
+        "binding": {
+          "type": "property",
+          "name": "foo"
+        }
+      }
     ]
   }
 ]

--- a/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
@@ -430,7 +430,6 @@ describe('features/create-append-anything - append menu provider', function() {
 
           // then
           expect(spy).to.have.been.called;
-
         }));
 
 
@@ -450,7 +449,6 @@ describe('features/create-append-anything - append menu provider', function() {
 
           // then
           expect(spy).to.have.been.called;
-
         }));
 
       });

--- a/test/spec/element-templates/append-menu/ElementTemplatesAppendProvider.spec.js
+++ b/test/spec/element-templates/append-menu/ElementTemplatesAppendProvider.spec.js
@@ -207,6 +207,48 @@ describe('<ElementTemplatesAppendProvider>', function() {
       expect(isTemplateApplied(newElement, template)).to.be.true;
     }));
 
+
+    describe('should trigger create mode', function() {
+
+      it('boundary event', inject(function(elementRegistry, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const spy = sinon.spy();
+
+        eventBus.on('create.init', spy);
+
+        // when
+        openPopup(task);
+
+        triggerAction('append.template-example.MessageBoundaryEventTemplate');
+
+        // then
+        expect(spy).to.have.been.called;
+      }));
+
+
+      it('link intermediate catch event', inject(function(elementRegistry, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const spy = sinon.spy();
+
+        eventBus.on('create.init', spy);
+
+        // when
+        openPopup(task);
+
+        triggerAction('append.template-example.LinkIntermediateCatchEventTemplate');
+
+        // then
+        expect(spy).to.have.been.called;
+      }));
+
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

In line with the rules applied [here](https://github.com/bpmn-io/bpmn-js-create-append-anything/blob/2d5e2a11384178f7d866e6a9ab80662da0114705/lib/create-append-anything/append-menu/AppendMenuProvider.js#L168) boundary events and link catch events cannot be auto-placed anymore and create mode will be triggered on click and drag.

![brave_l2YAiHx2X6](https://github.com/user-attachments/assets/8c664b34-37cb-407a-be6b-ba1efda9fed7)

Related to https://github.com/camunda/camunda-modeler/issues/5193

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
