### PR TITLE
feat: implement auto-attach for boundary events to the active element

### DIFF
--- a/lib/create-append-anything/append-menu/AppendMenuProvider.js
+++ b/lib/create-append-anything/append-menu/AppendMenuProvider.js
@@ -139,22 +139,18 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
   const modeling = this._modeling;
   const selection = this._selection;
 
-  const autoPlaceElement = () => {
-    const newElement = elementFactory.create('shape', target);
+  const autoPlaceElement = (newElement) => {
     autoPlace.append(element, newElement);
   };
 
-  const autoAttach = () => {
-    const newElement = elementFactory.create('shape', target);
+  const autoAttach = (newElement) => {
     const attachPosition = getBoundaryElementAttachPosition(element);
 
     const createdElements = modeling.createElements(newElement, attachPosition, element, { attach: true });
     selection.select(createdElements[0]);
   };
 
-  const manualPlaceElement = (event) => {
-    const newElement = elementFactory.create('shape', target);
-
+  const manualPlaceElement = (event, newElement) => {
     if (event instanceof KeyboardEvent) {
       event = mouse.getLastMoveEvent();
     }
@@ -164,32 +160,40 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
     });
   };
 
-  let clickAction;
-  if (this._canAutoAttach(element, target)) {
-    clickAction = autoAttach;
-  } else if (this._canAutoPlaceElement(target)) {
-    clickAction = autoPlaceElement;
-  } else {
-    clickAction = manualPlaceElement;
-  }
+  const clickActionHandler = (event) => {
+    const newElement = elementFactory.create('shape', target);
+
+    if (this._canAutoAttach(element, newElement, target)) {
+      autoAttach(newElement);
+    } else if (this._canAutoPlaceElement(target)) {
+      autoPlaceElement(newElement);
+    } else {
+      manualPlaceElement(event, newElement);
+    }
+  };
+
+  const dragActionHandler = (event) => {
+    const newElement = elementFactory.create('shape', target);
+    manualPlaceElement(event, newElement);
+  };
 
   return {
-    click: clickAction,
-    dragstart: manualPlaceElement
+    click: clickActionHandler,
+    dragstart: dragActionHandler
   };
 };
 
 /**
- * Check if target element can be auto-attached to the given element.
+ * Check if a target element can be auto-attached to the given element.
  *
  * @param {djs.model.Element} element
+ * @param {djs.model.Element} newElement
  * @param {Object} target
  *
  * @return {boolean}
  */
-AppendMenuProvider.prototype._canAutoAttach = function(element, target) {
+AppendMenuProvider.prototype._canAutoAttach = function(element, newElement, target) {
   if (target.type === 'bpmn:BoundaryEvent') {
-    const newElement = this._elementFactory.create('shape', target);
     const attachPosition = getBoundaryElementAttachPosition(element);
 
     const canAttach = this._rules.allowed('shape.attach', {

--- a/lib/create-append-anything/append-menu/AppendMenuProvider.js
+++ b/lib/create-append-anything/append-menu/AppendMenuProvider.js
@@ -7,7 +7,7 @@ import { CREATE_OPTIONS } from '../../util/CreateOptionsUtil';
 export default function AppendMenuProvider(
     elementFactory, popupMenu,
     create, autoPlace, rules,
-    mouse, translate
+    mouse, translate, modeling
 ) {
 
   this._elementFactory = elementFactory;
@@ -15,9 +15,9 @@ export default function AppendMenuProvider(
   this._create = create;
   this._autoPlace = autoPlace;
   this._rules = rules;
-  this._create = create;
   this._mouse = mouse;
   this._translate = translate;
+  this._modeling = modeling;
 
   this.register();
 }
@@ -29,7 +29,8 @@ AppendMenuProvider.$inject = [
   'autoPlace',
   'rules',
   'mouse',
-  'translate'
+  'translate',
+  'modeling'
 ];
 
 /**
@@ -123,7 +124,7 @@ AppendMenuProvider.prototype._filterEntries = function(entries) {
 /**
  * Create an action for a given target.
  *
- * @param {djs.model.Base} element
+ * @param {djs.model.Element} element
  * @param {Object} target
  *
  * @return {Object}
@@ -133,11 +134,18 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
   const autoPlace = this._autoPlace;
   const create = this._create;
   const mouse = this._mouse;
-
+  const modeling = this._modeling;
 
   const autoPlaceElement = () => {
     const newElement = elementFactory.create('shape', target);
     autoPlace.append(element, newElement);
+  };
+
+  const autoAttach = () => {
+    const newElement = elementFactory.create('shape', target);
+    const attachPosition = getBoundaryElementAttachPosition(element);
+
+    modeling.createElements(newElement, attachPosition, element, { attach: true });
   };
 
   const manualPlaceElement = (event) => {
@@ -152,10 +160,45 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
     });
   };
 
+  let clickAction;
+  if (this._canAutoAttach(element, target)) {
+    clickAction = autoAttach;
+  } else if (this._canAutoPlaceElement(target)) {
+    clickAction = autoPlaceElement;
+  } else {
+    clickAction = manualPlaceElement;
+  }
+
   return {
-    click: this._canAutoPlaceElement(target) ? autoPlaceElement : manualPlaceElement,
+    click: clickAction,
     dragstart: manualPlaceElement
   };
+};
+
+/**
+ * Check if target element can be auto-attached to the given element.
+ *
+ * @param {djs.model.Element} element
+ * @param {Object} target
+ *
+ * @return {boolean}
+ */
+AppendMenuProvider.prototype._canAutoAttach = function(element, target) {
+  if (target.type === 'bpmn:BoundaryEvent') {
+    const newElement = this._elementFactory.create('shape', target);
+    const attachPosition = getBoundaryElementAttachPosition(element);
+
+    const canAttach = this._rules.allowed('shape.attach', {
+      shape: newElement,
+      target: element,
+      position: attachPosition
+    });
+
+    // Only auto-attach if the element has no existing attachers and attachment is allowed
+    return canAttach === 'attach' && (!element.attachers || element.attachers.length === 0);
+  }
+
+  return false;
 };
 
 /**
@@ -181,4 +224,11 @@ AppendMenuProvider.prototype._canAutoPlaceElement = (target) => {
   }
 
   return true;
+};
+
+const getBoundaryElementAttachPosition = (targetElement) => {
+  return {
+    x: targetElement.x + targetElement.width / 2,
+    y: targetElement.y + targetElement.height
+  };
 };

--- a/lib/create-append-anything/append-menu/AppendMenuProvider.js
+++ b/lib/create-append-anything/append-menu/AppendMenuProvider.js
@@ -7,7 +7,7 @@ import { CREATE_OPTIONS } from '../../util/CreateOptionsUtil';
 export default function AppendMenuProvider(
     elementFactory, popupMenu,
     create, autoPlace, rules,
-    mouse, translate, modeling
+    mouse, translate, modeling, selection
 ) {
 
   this._elementFactory = elementFactory;
@@ -18,6 +18,7 @@ export default function AppendMenuProvider(
   this._mouse = mouse;
   this._translate = translate;
   this._modeling = modeling;
+  this._selection = selection;
 
   this.register();
 }
@@ -30,7 +31,8 @@ AppendMenuProvider.$inject = [
   'rules',
   'mouse',
   'translate',
-  'modeling'
+  'modeling',
+  'selection'
 ];
 
 /**
@@ -135,6 +137,7 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
   const create = this._create;
   const mouse = this._mouse;
   const modeling = this._modeling;
+  const selection = this._selection;
 
   const autoPlaceElement = () => {
     const newElement = elementFactory.create('shape', target);
@@ -145,7 +148,8 @@ AppendMenuProvider.prototype._createEntryAction = function(element, target) {
     const newElement = elementFactory.create('shape', target);
     const attachPosition = getBoundaryElementAttachPosition(element);
 
-    modeling.createElements(newElement, attachPosition, element, { attach: true });
+    const createdElements = modeling.createElements(newElement, attachPosition, element, { attach: true });
+    selection.select(createdElements[0]);
   };
 
   const manualPlaceElement = (event) => {

--- a/test/spec/create-append-anything/append-menu/AppendMenuProvider.bpmn
+++ b/test/spec/create-append-anything/append-menu/AppendMenuProvider.bpmn
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0-rc.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-rc.2-dev">
   <bpmn:process id="Process_07k5b99" isExecutable="false">
     <bpmn:endEvent id="EndEvent">
-      <bpmn:incoming>Flow_0zr9ajj</bpmn:incoming>
+      <bpmn:incoming>Flow_1e7wtwg</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:task id="Task">
       <bpmn:incoming>Flow_00dqsyf</bpmn:incoming>
@@ -11,13 +11,30 @@
     <bpmn:startEvent id="StartEvent">
       <bpmn:outgoing>Flow_00dqsyf</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0zr9ajj" sourceRef="Task" targetRef="EndEvent" />
+    <bpmn:sequenceFlow id="Flow_0zr9ajj" sourceRef="Task" targetRef="TaskWithBoundary" />
     <bpmn:sequenceFlow id="Flow_00dqsyf" sourceRef="StartEvent" targetRef="Task" />
+    <bpmn:task id="TaskWithBoundary">
+      <bpmn:incoming>Flow_0zr9ajj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e7wtwg</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1e7wtwg" sourceRef="TaskWithBoundary" targetRef="EndEvent" />
+    <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="TaskWithBoundary">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_15wnjmk" />
+    </bpmn:boundaryEvent>
+    <bpmn:eventBasedGateway id="EventBasedGateway">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:receiveTask id="ReceiveTaskAfterGateway">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="StartEvent" targetRef="EventBasedGateway" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="EventBasedGateway" targetRef="ReceiveTaskAfterGateway" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_07k5b99">
       <bpmndi:BPMNShape id="BPMNShape_059bl0s" bpmnElement="EndEvent">
-        <dc:Bounds x="392" y="102" width="36" height="36" />
+        <dc:Bounds x="562" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0iyyd6k" bpmnElement="Task">
         <dc:Bounds x="240" y="80" width="100" height="80" />
@@ -25,13 +42,38 @@
       <bpmndi:BPMNShape id="BPMNShape_13pubz2" bpmnElement="StartEvent">
         <dc:Bounds x="152" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TaskWithBoundary_di" bpmnElement="TaskWithBoundary">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EventBasedGateway_di" bpmnElement="EventBasedGateway">
+        <dc:Bounds x="240" y="250" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReceiveTaskAfterGateway_di" bpmnElement="ReceiveTaskAfterGateway">
+        <dc:Bounds x="350" y="235" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="432" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_1tnzw52" bpmnElement="Flow_0zr9ajj">
         <di:waypoint x="340" y="120" />
-        <di:waypoint x="392" y="120" />
+        <di:waypoint x="400" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_1xyp7qo" bpmnElement="Flow_00dqsyf">
         <di:waypoint x="188" y="120" />
         <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e7wtwg_di" bpmnElement="Flow_1e7wtwg">
+        <di:waypoint x="500" y="120" />
+        <di:waypoint x="562" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="170" y="138" />
+        <di:waypoint x="170" y="275" />
+        <di:waypoint x="240" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="290" y="275" />
+        <di:waypoint x="350" y="275" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
@@ -476,7 +476,7 @@ describe('features/create-append-anything - append menu provider', function() {
         expect(receiveTask.attachers || []).to.be.empty;
       }));
 
-      it('should auto-attach when element has no attachers and rules allow', inject(function(elementRegistry) {
+      it('should auto-attach when element has no attachers and rules allow', inject(function(elementRegistry, selection) {
 
         // given
         const task = elementRegistry.get('Task');
@@ -492,6 +492,11 @@ describe('features/create-append-anything - append menu provider', function() {
         // Boundary event should be attached
         expect(task.attachers).to.have.length(1);
         expect(task.attachers[0].type).to.equal('bpmn:BoundaryEvent');
+
+        // Boundary event should be selected
+        const boundaryEvent = task.attachers[0];
+        expect(selection.get()).to.have.length(1);
+        expect(selection.get()[0]).to.equal(boundaryEvent);
       }));
 
       it('should append via dragstart', inject(function(elementRegistry, eventBus) {

--- a/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendMenuProvider.spec.js
@@ -413,49 +413,151 @@ describe('features/create-append-anything - append menu provider', function() {
         // then
         expect(outgoingFlows).to.have.length(2);
       }));
+    });
+
+    describe('should trigger create mode', function() {
+      it('link intermediate catch event', inject(function(elementRegistry, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task');
+
+        const initSpy = spy();
+
+        eventBus.on('create.init', initSpy);
+
+        // when
+        openPopup(task);
+
+        triggerAction('append-link-intermediate-catch');
+
+        // then
+        expect(initSpy).to.have.been.called;
+      }));
+    });
 
 
-      describe('should trigger create mode', function() {
+    describe('boundary event', function() {
 
-        it('boundary event', inject(function(elementRegistry, eventBus) {
+      it('should NOT auto-attach when element already has attachers', inject(function(elementRegistry, eventBus) {
 
-          // given
-          const task = elementRegistry.get('Task');
+        // given
+        const taskWithBoundary = elementRegistry.get('TaskWithBoundary');
+        const createInitSpy = spy();
 
-          const initSpy = spy();
+        expect(taskWithBoundary.attachers).to.have.length(1);
 
-          eventBus.on('create.init', initSpy);
+        eventBus.on('create.init', createInitSpy);
 
-          // when
-          openPopup(task);
+        // when
+        openPopup(taskWithBoundary);
+        triggerAction('append-timer-boundary');
 
-          triggerAction('append-non-interrupting-message-boundary');
+        // then
+        // Should trigger create mode (manual placement) instead of auto-attach
+        expect(createInitSpy).to.have.been.called;
+        expect(taskWithBoundary.attachers).to.have.length(1);
+      }));
 
-          // then
-          expect(initSpy).to.have.been.called;
-        }));
+      it('should NOT auto-attach when rules disallow attachment', inject(function(elementRegistry, eventBus) {
 
+        // given
+        const receiveTask = elementRegistry.get('ReceiveTaskAfterGateway');
+        const createInitSpy = spy();
 
-        it('link intermediate catch event', inject(function(elementRegistry, eventBus) {
+        eventBus.on('create.init', createInitSpy);
 
-          // given
-          const task = elementRegistry.get('Task');
+        // when
+        openPopup(receiveTask);
+        triggerAction('append-timer-boundary');
 
-          const initSpy = spy();
+        // then
+        // Should trigger create mode (manual placement) because rules.allowed returns false
+        expect(createInitSpy).to.have.been.called;
+        expect(receiveTask.attachers || []).to.be.empty;
+      }));
 
-          eventBus.on('create.init', initSpy);
+      it('should auto-attach when element has no attachers and rules allow', inject(function(elementRegistry) {
 
-          // when
-          openPopup(task);
+        // given
+        const task = elementRegistry.get('Task');
 
-          triggerAction('append-link-intermediate-catch');
+        // Verify task has no boundary events
+        expect(task.attachers || []).to.be.empty;
 
-          // then
-          expect(initSpy).to.have.been.called;
-        }));
+        // when
+        openPopup(task);
+        triggerAction('append-timer-boundary');
 
-      });
+        // then
+        // Boundary event should be attached
+        expect(task.attachers).to.have.length(1);
+        expect(task.attachers[0].type).to.equal('bpmn:BoundaryEvent');
+      }));
 
+      it('should append via dragstart', inject(function(elementRegistry, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task');
+        const createSpy = spy();
+        const endSpy = spy();
+
+        eventBus.on('create.start', createSpy);
+        eventBus.on('create.end', endSpy);
+
+        expect(task.attachers || []).to.be.empty;
+
+        // when
+        openPopup(task);
+        placeBoundaryEventOnTask(task, 'append-timer-boundary');
+
+        // then
+        expect(createSpy).to.have.been.called;
+        expect(endSpy).to.have.been.called;
+        expect(task.attachers).to.have.length(1);
+      }));
+
+      it('should undo', inject(function(elementRegistry, commandStack) {
+
+        // given
+        const task = elementRegistry.get('Task');
+
+        expect(task.attachers || []).to.be.empty;
+
+        // when
+        openPopup(task);
+        triggerAction('append-timer-boundary');
+
+        // then
+        expect(task.attachers).to.have.length(1);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(task.attachers).to.be.empty;
+      }));
+
+      it('should redo', inject(function(elementRegistry, commandStack) {
+
+        // given
+        const task = elementRegistry.get('Task');
+
+        expect(task.attachers || []).to.be.empty;
+
+        // when
+        openPopup(task);
+        triggerAction('append-timer-boundary');
+        commandStack.undo();
+
+        // then
+        expect(task.attachers).to.be.empty;
+
+        // when
+        commandStack.redo();
+
+        // then
+        expect(task.attachers).to.have.length(1);
+      }));
     });
 
 
@@ -683,5 +785,20 @@ function placeDragElement(element, action) {
   triggerAction(action, 'dragstart');
 
   dragging.hover({ element: processElement });
+  dragging.end();
+}
+
+function placeBoundaryEventOnTask(task, action) {
+  const dragging = getBpmnJS().get('dragging');
+  const elementRegistry = getBpmnJS().get('elementRegistry');
+
+  triggerAction(action, 'dragstart');
+
+  const taskGfx = elementRegistry.getGraphics(task);
+  dragging.hover({ element: task, gfx: taskGfx });
+
+  // Move to the bottom edge of the task (boundary position)
+  dragging.move(globalEvent(taskGfx, { x: task.x + task.width / 2, y: task.y + task.height }));
+
   dragging.end();
 }


### PR DESCRIPTION
### Proposed Changes
Related to https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/69

Previously appending a boundary event to an activity doesn't immediately attach event to the activity and needs to be manually placed:
![Image](https://github.com/user-attachments/assets/ddb288ab-23c5-4e8a-aa2e-2852e4b3ef8c)

This PR allows boundary events to auto-attach directly when the target element has no existing attachers and the rules allow attachment. Otherwise, it falls back to manual placement mode.

https://github.com/user-attachments/assets/0822d6bf-572f-4f8d-a23c-5b2f26de61a3

**Try out:**
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#2369-auto-attach-boundary-event-to-element

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
