### PR TITLE
fix: fix the insert plain entry index calculation in case when previousIndex or nextIndex is '0'(falsy)

### DIFF
--- a/lib/element-templates/remove-templates/RemoveTemplateReplaceProvider.js
+++ b/lib/element-templates/remove-templates/RemoveTemplateReplaceProvider.js
@@ -111,7 +111,7 @@ RemoveTemplateReplaceProvider.prototype.getPlainEntry = function(element, entrie
   // insert after previous option, if it exists
   const previousIndex = getOptionIndex(options, optionIndex - 1, entries);
 
-  if (previousIndex) {
+  if (previousIndex !== false) {
     return [
       previousIndex + 1,
       entry
@@ -121,7 +121,7 @@ RemoveTemplateReplaceProvider.prototype.getPlainEntry = function(element, entrie
   // insert before next option, if it exists
   const nextIndex = getOptionIndex(options, optionIndex + 1, entries);
 
-  if (nextIndex) {
+  if (nextIndex !== false) {
     return [
       nextIndex,
       entry


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/48

fix the insert plain entry index calculation in case when previousIndex or nextIndex is '0'(falsy).

I didn't touch the tests which currently only ensure that an element is present in the menu, not its specific position. The current approach relies a lot on `Object.entries` or `Object.keys` manipulations, which doesn't guarantee a [consistent order](https://stackoverflow.com/a/5525820). So we would probably break these tests each time we add a new option, which is what we faced [here](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/47#issuecomment-2612446136).

**Try out:**
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#48-make-remove-template-as-first-option

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
