### PR TITLE
fix: disallow append action for compensation activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-create-append-anything](https://github.com/bpmn-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: disallow append action for compensation activities ([#86](https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/86))
+
 ## 1.3.0
 
 * `FEAT`: support multi-step pop-up for templates ([#78](https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/78))

--- a/lib/create-append-anything/append-menu/AppendRules.js
+++ b/lib/create-append-anything/append-menu/AppendRules.js
@@ -57,6 +57,10 @@ AppendRules.prototype.init = function() {
       return false;
     }
 
+    if (businessObject.isForCompensation) {
+      return false;
+    }
+
     if (is(source, 'bpmn:IntermediateThrowEvent') && hasEventDefinition(source, 'bpmn:LinkEventDefinition')) {
       return false;
     }

--- a/test/spec/create-append-anything/append-menu/AppendRules.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendRules.spec.js
@@ -90,6 +90,22 @@ describe('features/create-append-anything - rules', function() {
     }));
 
 
+    it('should not allow for compensation activity', inject(function(elementFactory, rules) {
+
+      // given
+      const element = elementFactory.createShape({
+        type: 'bpmn:Task',
+        isForCompensation: true
+      });
+
+      // when
+      const result = rules.allowed('shape.append', { element });
+
+      // then
+      expect(result).to.be.false;
+    }));
+
+
     describe('connections', function() {
 
       it('should not allow for sequence flows', inject(function(elementRegistry, rules) {


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/86

Disallow append action for compensation activities.

<img width="585" height="352" alt="image" src="https://github.com/user-attachments/assets/dbe674ff-f50d-4b71-9010-201b98fd2350" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
