### PR TITLE
feat: reuse shared menu entries list and allow to style menus width with css variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to [bpmn-js-create-append-anything](https://github.com/bpmn-
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: disallow append action for compensation activities ([#86](https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/86))
+* `FEAT`: allow overriding the create/append menu width via css variable
+
+### Breaking Changes
+
+* Require `bpmn-js@18.22.0` as a peer dependency ([#88](https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/88))
 
 ## 1.3.0
 

--- a/lib/create-append-anything/append-menu/AppendContextPadProvider.js
+++ b/lib/create-append-anything/append-menu/AppendContextPadProvider.js
@@ -65,7 +65,7 @@ AppendContextPadProvider.prototype.getContextPadEntries = function(element) {
 
             popupMenu.open(element, 'bpmn-append', position, {
               title: translate('Append element'),
-              width: 360,
+              width: 'var(--bpmn-append-popup-width, 300px)',
               search: true
             });
           }

--- a/lib/create-append-anything/append-menu/AppendContextPadProvider.js
+++ b/lib/create-append-anything/append-menu/AppendContextPadProvider.js
@@ -65,7 +65,7 @@ AppendContextPadProvider.prototype.getContextPadEntries = function(element) {
 
             popupMenu.open(element, 'bpmn-append', position, {
               title: translate('Append element'),
-              width: 300,
+              width: 360,
               search: true
             });
           }

--- a/lib/create-append-anything/append-menu/AppendMenuProvider.js
+++ b/lib/create-append-anything/append-menu/AppendMenuProvider.js
@@ -44,7 +44,7 @@ AppendMenuProvider.prototype.register = function() {
 };
 
 /**
- * Returns the append options for the given element as nested popup menu entries.
+ * Returns the append options for the given element as flat popup menu entries.
  *
  * @param {djs.model.Base} element
  *

--- a/lib/create-append-anything/append-menu/AppendMenuProvider.js
+++ b/lib/create-append-anything/append-menu/AppendMenuProvider.js
@@ -1,5 +1,6 @@
 import { isUndefined } from 'min-dash';
 import { CREATE_OPTIONS } from '../../util/CreateOptionsUtil';
+import { buildMenuEntries } from '../../util/PopupMenuEntriesUtil';
 
 /**
  * This module is an append menu provider for the popup menu.
@@ -43,84 +44,50 @@ AppendMenuProvider.prototype.register = function() {
 };
 
 /**
- * Gets the append options for the given element as menu entries
+ * Returns the append options for the given element as nested popup menu entries.
  *
  * @param {djs.model.Base} element
  *
- * @return {Array<Object>} a list of menu entry items
+ * @return {Object} menu entries keyed by id
  */
 AppendMenuProvider.prototype.getPopupMenuEntries = function(element) {
-  const rules = this._rules;
-  const translate = this._translate;
-
-  const entries = {};
-
-  if (!rules.allowed('shape.append', { element: element })) {
-    return [];
+  if (!this._rules.allowed('shape.append', { element: element })) {
+    return {};
   }
 
-  // filter out elements with no incoming connections
-  const appendOptions = this._filterEntries(CREATE_OPTIONS);
-
-  // map options to menu entries
-  appendOptions.forEach(option => {
-    const {
-      actionName,
-      className,
-      label,
-      target,
-      description,
-      group,
-      search,
-      rank
-    } = option;
-
-    entries[`append-${actionName}`] = {
-      label: label && translate(label),
-      className,
-      description,
-      group: group && {
-        ...group,
-        name: translate(group.name)
-      },
-      search,
-      rank,
-      action: this._createEntryAction(element, target)
-    };
+  return buildMenuEntries(CREATE_OPTIONS, {
+    idPrefix: 'append',
+    translate: this._translate,
+    filter: (option) => this._includeOption(option),
+    createAction: (option) => this._createEntryAction(element, option.target)
   });
-
-  return entries;
 };
 
 /**
- * Filter out entries from the options.
+ * Whether an option should appear in the append menu.
  *
- * @param {Array<Object>} entries
+ * @param {Object} option
  *
- * @return {Array<Object>} filtered entries
+ * @return {boolean}
  */
-AppendMenuProvider.prototype._filterEntries = function(entries) {
-  return entries.filter(option => {
+AppendMenuProvider.prototype._includeOption = function(option) {
+  const {
+    type,
+    eventDefinitionType
+  } = option.target;
 
-    const target = option.target;
-    const {
-      type,
-      eventDefinitionType
-    } = target;
+  if ([
+    'bpmn:StartEvent',
+    'bpmn:Participant'
+  ].includes(type)) {
+    return false;
+  }
 
-    if ([
-      'bpmn:StartEvent',
-      'bpmn:Participant'
-    ].includes(type)) {
-      return false;
-    }
+  if (type === 'bpmn:BoundaryEvent' && isUndefined(eventDefinitionType)) {
+    return false;
+  }
 
-    if (type === 'bpmn:BoundaryEvent' && isUndefined(eventDefinitionType)) {
-      return false;
-    }
-
-    return true;
-  });
+  return true;
 };
 
 /**

--- a/lib/create-append-anything/create-menu/CreateMenuProvider.js
+++ b/lib/create-append-anything/create-menu/CreateMenuProvider.js
@@ -35,7 +35,7 @@ CreateMenuProvider.prototype.register = function() {
 };
 
 /**
- * Returns the create options as nested popup menu entries.
+ * Returns the create options as flat popup menu entries.
  *
  * @return {Object} menu entries keyed by id
  */

--- a/lib/create-append-anything/create-menu/CreateMenuProvider.js
+++ b/lib/create-append-anything/create-menu/CreateMenuProvider.js
@@ -1,4 +1,5 @@
 import { CREATE_OPTIONS } from '../../util/CreateOptionsUtil';
+import { buildMenuEntries } from '../../util/PopupMenuEntriesUtil';
 
 /**
  * This module is a create menu provider for the popup menu.
@@ -34,49 +35,23 @@ CreateMenuProvider.prototype.register = function() {
 };
 
 /**
- * Returns the create options as menu entries
+ * Returns the create options as nested popup menu entries.
  *
- * @param {djs.model.Base} element
- *
- * @return {Array<Object>} a list of menu entry items
+ * @return {Object} menu entries keyed by id
  */
 CreateMenuProvider.prototype.getPopupMenuEntries = function() {
+  return buildMenuEntries(CREATE_OPTIONS, {
+    idPrefix: 'create',
+    translate: this._translate,
+    createAction: (option) => {
+      const targetAction = this._createEntryAction(option.target);
 
-  const entries = {};
-
-  // map options to menu entries
-  CREATE_OPTIONS.forEach(option => {
-    const {
-      actionName,
-      className,
-      label,
-      target,
-      description,
-      group,
-      search,
-      rank
-    } = option;
-
-    const targetAction = this._createEntryAction(target);
-
-    entries[`create-${actionName}`] = {
-      label: label && this._translate(label),
-      className,
-      description,
-      group: group && {
-        ...group,
-        name: this._translate(group.name)
-      },
-      search,
-      rank,
-      action: {
+      return {
         click: targetAction,
         dragstart: targetAction
-      }
-    };
+      };
+    }
   });
-
-  return entries;
 };
 
 /**

--- a/lib/create-append-anything/create-menu/CreatePaletteProvider.js
+++ b/lib/create-append-anything/create-menu/CreatePaletteProvider.js
@@ -76,7 +76,7 @@ CreatePaletteProvider.prototype.getPaletteEntries = function(element) {
 
           popupMenu.open(element, 'bpmn-create', position, {
             title: translate('Create element'),
-            width: 300,
+            width: 360,
             search: true
           });
         }

--- a/lib/create-append-anything/create-menu/CreatePaletteProvider.js
+++ b/lib/create-append-anything/create-menu/CreatePaletteProvider.js
@@ -76,7 +76,7 @@ CreatePaletteProvider.prototype.getPaletteEntries = function(element) {
 
           popupMenu.open(element, 'bpmn-create', position, {
             title: translate('Create element'),
-            width: 360,
+            width: 'var(--bpmn-create-popup-width, 300px)',
             search: true
           });
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,12 @@
 export { default as CreateAppendAnythingModule } from './create-append-anything';
 export { default as CreateAppendElementTemplatesModule } from './element-templates';
 export { default as RemoveTemplatesModule } from './element-templates/remove-templates';
+
+export {
+  ALL_EVENTS,
+  TASK,
+  GATEWAY,
+  SUBPROCESS,
+  DATA_OBJECTS,
+  PARTICIPANT
+} from './util/CreateOptionsUtil';

--- a/lib/util/CreateOptionsUtil.js
+++ b/lib/util/CreateOptionsUtil.js
@@ -1,691 +1,149 @@
-export const EVENT_GROUP = {
-  id: 'events',
-  name: 'Events'
+import { PopupEntries } from 'bpmn-js/lib/features/popup-menu';
+
+/**
+ * Build a create/append option from the shared `PopupEntries` catalog. The
+ * `actionName` defaults to the catalog `id`.
+ *
+ * @param {string} id popup entry id
+ * @param {Object} [extra] fields to override or add (e.g. `search`, `rank`, `actionName`)
+ *
+ * @return {Object}
+ */
+const createOption = (id, extra = {}) => {
+  const entry = PopupEntries[id];
+
+  if (!entry) {
+    throw new Error('unknown popup entry <' + id + '>');
+  }
+
+  return {
+    ...entry,
+    actionName: id,
+    ...extra
+  };
 };
 
-export const TASK_GROUP = {
-  id: 'tasks',
-  name: 'Tasks'
-};
-
-export const DATA_GROUP = {
-  id: 'data',
-  name: 'Data'
-};
-
-export const PARTICIPANT_GROUP = {
-  id: 'participants',
-  name: 'Participants'
-};
-
-export const SUBPROCESS_GROUP = {
-  id: 'subprocess',
-  name: 'Sub-processes'
-};
-
-export const GATEWAY_GROUP = {
-  id: 'gateways',
-  name: 'Gateways'
-};
+export const EVENT_GROUP = { id: 'events', name: 'Events' };
+export const TASK_GROUP = { id: 'tasks', name: 'Tasks' };
+export const GATEWAY_GROUP = { id: 'gateways', name: 'Gateways' };
+export const SUBPROCESS_GROUP = { id: 'subprocess', name: 'Sub-processes' };
+export const DATA_GROUP = { id: 'data', name: 'Data' };
+export const PARTICIPANT_GROUP = { id: 'participants', name: 'Participants' };
 
 export const NONE_EVENTS = [
-  {
-    label: 'Start event',
-    actionName: 'none-start-event',
-    className: 'bpmn-icon-start-event-none',
-    target: {
-      type: 'bpmn:StartEvent'
-    }
-  },
-  {
-    label: 'Intermediate throw event',
-    actionName: 'none-intermediate-throwing',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent'
-    }
-  },
-  {
-    label: 'Boundary event',
-    actionName: 'none-boundary-event',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:BoundaryEvent'
-    }
-  },
-  {
-    label: 'End event',
-    actionName: 'none-end-event',
-    className: 'bpmn-icon-end-event-none',
-    target: {
-      type: 'bpmn:EndEvent'
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP }));
+  createOption('none-start-event', { group: EVENT_GROUP }),
+  createOption('none-intermediate-throwing', { group: EVENT_GROUP }),
+  createOption('none-boundary-event', { group: EVENT_GROUP }),
+  createOption('none-end-event', { group: EVENT_GROUP })
+];
 
 export const TYPED_START_EVENTS = [
-  {
-    label: 'Message start event',
-    actionName: 'message-start',
-    className: 'bpmn-icon-start-event-message',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Timer start event',
-    actionName: 'timer-start',
-    className: 'bpmn-icon-start-event-timer',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
-    }
-  },
-  {
-    label: 'Conditional start event',
-    actionName: 'conditional-start',
-    className: 'bpmn-icon-start-event-condition',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-    }
-  },
-  {
-    label: 'Signal start event',
-    actionName: 'signal-start',
-    className: 'bpmn-icon-start-event-signal',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP }));
+  createOption('message-start', { group: EVENT_GROUP }),
+  createOption('timer-start', { group: EVENT_GROUP }),
+  createOption('conditional-start', { group: EVENT_GROUP }),
+  createOption('signal-start', { group: EVENT_GROUP })
+];
 
 export const TYPED_NON_INTERRUPTING_START_EVENTS = [
-  {
-    label: 'Message start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-message-start',
-    className: 'bpmn-icon-start-event-non-interrupting-message',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Timer start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-timer-start',
-    className: 'bpmn-icon-start-event-non-interrupting-timer',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Conditional start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-conditional-start',
-    className: 'bpmn-icon-start-event-non-interrupting-condition',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Signal start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-signal-start',
-    className: 'bpmn-icon-start-event-non-interrupting-signal',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Escalation start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-escalation-start',
-    className: 'bpmn-icon-start-event-non-interrupting-escalation',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      isInterrupting: false
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP, rank: -1 }));
+  createOption('non-interrupting-message-start', { group: EVENT_GROUP, actionName: 'replace-with-non-interrupting-message-start', rank: -1 }),
+  createOption('non-interrupting-timer-start', { group: EVENT_GROUP, actionName: 'replace-with-non-interrupting-timer-start', rank: -1 }),
+  createOption('non-interrupting-conditional-start', { group: EVENT_GROUP, actionName: 'replace-with-non-interrupting-conditional-start', rank: -1 }),
+  createOption('non-interrupting-signal-start', { group: EVENT_GROUP, actionName: 'replace-with-non-interrupting-signal-start', rank: -1 }),
+  createOption('non-interrupting-escalation-start', { group: EVENT_GROUP, actionName: 'replace-with-non-interrupting-escalation-start', rank: -1 })
+];
 
 export const TYPED_INTERMEDIATE_EVENT = [
-  {
-    label: 'Message intermediate catch event',
-    actionName: 'message-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-message',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Message intermediate throw event',
-    actionName: 'message-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-message',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Timer intermediate catch event',
-    actionName: 'timer-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-timer',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
-    }
-  },
-  {
-    label: 'Escalation intermediate throw event',
-    actionName: 'escalation-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-escalation',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
-    }
-  },
-  {
-    label: 'Conditional intermediate catch event',
-    actionName: 'conditional-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-condition',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-    }
-  },
-  {
-    label: 'Link intermediate catch event',
-    actionName: 'link-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-link',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:LinkEventDefinition',
-      eventDefinitionAttrs: {
-        name: ''
-      }
-    }
-  },
-  {
-    label: 'Link intermediate throw event',
-    actionName: 'link-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-link',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:LinkEventDefinition',
-      eventDefinitionAttrs: {
-        name: ''
-      }
-    }
-  },
-  {
-    label: 'Compensation intermediate throw event',
-    actionName: 'compensation-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-compensation',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
-    }
-  },
-  {
-    label: 'Signal intermediate catch event',
-    actionName: 'signal-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-signal',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  },
-  {
-    label: 'Signal intermediate throw event',
-    actionName: 'signal-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-signal',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP }));
+  createOption('message-intermediate-catch', { group: EVENT_GROUP }),
+  createOption('message-intermediate-throw', { group: EVENT_GROUP }),
+  createOption('timer-intermediate-catch', { group: EVENT_GROUP }),
+  createOption('escalation-intermediate-throw', { group: EVENT_GROUP }),
+  createOption('conditional-intermediate-catch', { group: EVENT_GROUP }),
+  createOption('link-intermediate-catch', { group: EVENT_GROUP }),
+  createOption('link-intermediate-throw', { group: EVENT_GROUP }),
+  createOption('compensation-intermediate-throw', { group: EVENT_GROUP }),
+  createOption('signal-intermediate-catch', { group: EVENT_GROUP }),
+  createOption('signal-intermediate-throw', { group: EVENT_GROUP })
+];
 
 export const TYPED_BOUNDARY_EVENT = [
-  {
-    label: 'Message boundary event',
-    actionName: 'message-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-message',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Timer boundary event',
-    actionName: 'timer-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-timer',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
-    }
-  },
-  {
-    label: 'Escalation boundary event',
-    actionName: 'escalation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-escalation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
-    }
-  },
-  {
-    label: 'Conditional boundary event',
-    actionName: 'conditional-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-condition',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-    }
-  },
-  {
-    label: 'Error boundary event',
-    actionName: 'error-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-error',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition'
-    }
-  },
-  {
-    label: 'Cancel boundary event',
-    actionName: 'cancel-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-cancel',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CancelEventDefinition'
-    }
-  },
-  {
-    label: 'Signal boundary event',
-    actionName: 'signal-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-signal',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  },
-  {
-    label: 'Compensation boundary event',
-    actionName: 'compensation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-compensation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
-    }
-  },
-  {
-    label: 'Message boundary event (non-interrupting)',
-    actionName: 'non-interrupting-message-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-message',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Timer boundary event (non-interrupting)',
-    actionName: 'non-interrupting-timer-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-timer',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Escalation boundary event (non-interrupting)',
-    actionName: 'non-interrupting-escalation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-escalation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Conditional boundary event (non-interrupting)',
-    actionName: 'non-interrupting-conditional-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-condition',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Signal boundary event (non-interrupting)',
-    actionName: 'non-interrupting-signal-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-signal',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      cancelActivity: false
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP }));
+  createOption('message-boundary', { group: EVENT_GROUP }),
+  createOption('timer-boundary', { group: EVENT_GROUP }),
+  createOption('escalation-boundary', { group: EVENT_GROUP }),
+  createOption('conditional-boundary', { group: EVENT_GROUP }),
+  createOption('error-boundary', { group: EVENT_GROUP }),
+  createOption('cancel-boundary', { group: EVENT_GROUP }),
+  createOption('signal-boundary', { group: EVENT_GROUP }),
+  createOption('compensation-boundary', { group: EVENT_GROUP }),
+  createOption('non-interrupting-message-boundary', { group: EVENT_GROUP }),
+  createOption('non-interrupting-timer-boundary', { group: EVENT_GROUP }),
+  createOption('non-interrupting-escalation-boundary', { group: EVENT_GROUP }),
+  createOption('non-interrupting-conditional-boundary', { group: EVENT_GROUP }),
+  createOption('non-interrupting-signal-boundary', { group: EVENT_GROUP })
+];
 
 export const TYPED_END_EVENT = [
-  {
-    label: 'Message end event',
-    actionName: 'message-end',
-    className: 'bpmn-icon-end-event-message',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Escalation end event',
-    actionName: 'escalation-end',
-    className: 'bpmn-icon-end-event-escalation',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
-    }
-  },
-  {
-    label: 'Error end event',
-    actionName: 'error-end',
-    className: 'bpmn-icon-end-event-error',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition'
-    }
-  },
-  {
-    label: 'Cancel end event',
-    actionName: 'cancel-end',
-    className: 'bpmn-icon-end-event-cancel',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:CancelEventDefinition'
-    }
-  },
-  {
-    label: 'Compensation end event',
-    actionName: 'compensation-end',
-    className: 'bpmn-icon-end-event-compensation',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
-    }
-  },
-  {
-    label: 'Signal end event',
-    actionName: 'signal-end',
-    className: 'bpmn-icon-end-event-signal',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  },
-  {
-    label: 'Terminate end event',
-    actionName: 'terminate-end',
-    className: 'bpmn-icon-end-event-terminate',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:TerminateEventDefinition'
-    }
-  }
-].map(option => ({ ...option, group: EVENT_GROUP }));
+  createOption('message-end', { group: EVENT_GROUP }),
+  createOption('escalation-end', { group: EVENT_GROUP }),
+  createOption('error-end', { group: EVENT_GROUP }),
+  createOption('cancel-end', { group: EVENT_GROUP }),
+  createOption('compensation-end', { group: EVENT_GROUP }),
+  createOption('signal-end', { group: EVENT_GROUP }),
+  createOption('terminate-end', { group: EVENT_GROUP })
+];
 
 export const GATEWAY = [
-  {
-    label: 'Exclusive gateway',
-    actionName: 'exclusive-gateway',
-    className: 'bpmn-icon-gateway-xor',
-    target: {
-      type: 'bpmn:ExclusiveGateway'
-    }
-  },
-  {
-    label: 'Parallel gateway',
-    actionName: 'parallel-gateway',
-    className: 'bpmn-icon-gateway-parallel',
-    target: {
-      type: 'bpmn:ParallelGateway'
-    }
-  },
-  {
-    label: 'Inclusive gateway',
-    search: 'or',
-    actionName: 'inclusive-gateway',
-    className: 'bpmn-icon-gateway-or',
-    target: {
-      type: 'bpmn:InclusiveGateway'
-    },
-    rank: -1
-  },
-  {
-    label: 'Complex gateway',
-    actionName: 'complex-gateway',
-    className: 'bpmn-icon-gateway-complex',
-    target: {
-      type: 'bpmn:ComplexGateway'
-    },
-    rank: -1
-  },
-  {
-    label: 'Event-based gateway',
-    actionName: 'event-based-gateway',
-    className: 'bpmn-icon-gateway-eventbased',
-    target: {
-      type: 'bpmn:EventBasedGateway',
-      instantiate: false,
-      eventGatewayType: 'Exclusive'
-    }
-  }
-].map(option => ({ ...option, group: GATEWAY_GROUP }));
+  createOption('exclusive-gateway', { group: GATEWAY_GROUP }),
+  createOption('parallel-gateway', { group: GATEWAY_GROUP }),
+  createOption('inclusive-gateway', { group: GATEWAY_GROUP, search: 'or', rank: -1 }),
+  createOption('complex-gateway', { group: GATEWAY_GROUP, rank: -1 }),
+  createOption('event-based-gateway', { group: GATEWAY_GROUP })
+];
 
 export const SUBPROCESS = [
-  {
-    label: 'Call activity',
-    actionName: 'call-activity',
-    className: 'bpmn-icon-call-activity',
-    target: {
-      type: 'bpmn:CallActivity'
-    }
-  },
-  {
-    label: 'Transaction',
-    actionName: 'transaction',
-    className: 'bpmn-icon-transaction',
-    target: {
-      type: 'bpmn:Transaction',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Event sub-process',
-    search: 'subprocess',
-    actionName: 'event-subprocess',
-    className: 'bpmn-icon-event-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      triggeredByEvent: true,
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Sub-process (collapsed)',
-    search: 'subprocess',
-    actionName: 'collapsed-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: false
-    }
-  },
-  {
-    label: 'Sub-process (expanded)',
-    search: 'subprocess',
-    actionName: 'expanded-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process (collapsed)',
-    search: 'adhoc subprocess',
-    actionName: 'collapsed-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: false
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process (expanded)',
-    search: 'adhoc subprocess',
-    actionName: 'expanded-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: true
-    }
-  }
-].map(option => ({ ...option, group: SUBPROCESS_GROUP }));
+  createOption('call-activity', { group: SUBPROCESS_GROUP }),
+  createOption('transaction', { group: SUBPROCESS_GROUP }),
+  createOption('event-subprocess', { group: SUBPROCESS_GROUP, search: 'subprocess' }),
+  createOption('collapsed-subprocess', { group: SUBPROCESS_GROUP, search: 'subprocess' }),
+  createOption('expanded-subprocess', { group: SUBPROCESS_GROUP, search: 'subprocess' }),
+  createOption('collapsed-ad-hoc-subprocess', { group: SUBPROCESS_GROUP, search: 'adhoc subprocess' }),
+  createOption('expanded-ad-hoc-subprocess', { group: SUBPROCESS_GROUP, search: 'adhoc subprocess' })
+];
 
 export const TASK = [
-  {
-    label: 'Task',
-    actionName: 'task',
-    className: 'bpmn-icon-task',
-    target: {
-      type: 'bpmn:Task'
-    }
-  },
-  {
-    label: 'User task',
-    actionName: 'user-task',
-    className: 'bpmn-icon-user',
-    target: {
-      type: 'bpmn:UserTask'
-    }
-  },
-  {
-    label: 'Service task',
-    actionName: 'service-task',
-    className: 'bpmn-icon-service',
-    target: {
-      type: 'bpmn:ServiceTask'
-    }
-  },
-  {
-    label: 'Send task',
-    actionName: 'send-task',
-    className: 'bpmn-icon-send',
-    target: {
-      type: 'bpmn:SendTask'
-    },
-    rank: -1
-  },
-  {
-    label: 'Receive task',
-    actionName: 'receive-task',
-    className: 'bpmn-icon-receive',
-    target: {
-      type: 'bpmn:ReceiveTask'
-    },
-    rank: -1
-  },
-  {
-    label: 'Manual task',
-    actionName: 'manual-task',
-    className: 'bpmn-icon-manual',
-    target: {
-      type: 'bpmn:ManualTask'
-    },
-    rank: -1
-  },
-  {
-    label: 'Business rule task',
-    actionName: 'rule-task',
-    className: 'bpmn-icon-business-rule',
-    target: {
-      type: 'bpmn:BusinessRuleTask'
-    }
-  },
-  {
-    label: 'Script task',
-    actionName: 'script-task',
-    className: 'bpmn-icon-script',
-    target: {
-      type: 'bpmn:ScriptTask'
-    }
-  }
-].map(option => ({ ...option, group: TASK_GROUP }));
+  createOption('task', { group: TASK_GROUP }),
+  createOption('user-task', { group: TASK_GROUP }),
+  createOption('service-task', { group: TASK_GROUP }),
+  createOption('send-task', { group: TASK_GROUP, rank: -1 }),
+  createOption('receive-task', { group: TASK_GROUP, rank: -1 }),
+  createOption('manual-task', { group: TASK_GROUP, rank: -1 }),
+  createOption('rule-task', { group: TASK_GROUP }),
+  createOption('script-task', { group: TASK_GROUP })
+];
 
 export const DATA_OBJECTS = [
-  {
-    label: 'Data store reference',
-    actionName: 'data-store-reference',
-    className: 'bpmn-icon-data-store',
-    target: {
-      type: 'bpmn:DataStoreReference'
-    }
-  },
-  {
-    label: 'Data object reference',
-    actionName: 'data-object-reference',
-    className: 'bpmn-icon-data-object',
-    target: {
-      type: 'bpmn:DataObjectReference'
-    }
-  }
-].map(option => ({ ...option, group: DATA_GROUP }));
+  createOption('data-store-reference', { group: DATA_GROUP }),
+  createOption('data-object-reference', { group: DATA_GROUP })
+];
 
 export const PARTICIPANT = [
-  {
-    label: 'Expanded pool/participant',
-    search: 'Non-empty pool/participant',
-    actionName: 'expanded-pool',
-    className: 'bpmn-icon-participant',
-    target: {
-      type: 'bpmn:Participant',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Empty pool/participant',
-    search: 'Collapsed pool/participant',
-    actionName: 'collapsed-pool',
-    className: 'bpmn-icon-lane',
-    target: {
-      type: 'bpmn:Participant',
-      isExpanded: false
-    }
-  }
-].map(option => ({ ...option, group: PARTICIPANT_GROUP }));
+  createOption('expanded-pool', { group: PARTICIPANT_GROUP, search: 'Non-empty pool/participant' }),
+  createOption('collapsed-pool', { group: PARTICIPANT_GROUP, search: 'Collapsed pool/participant' })
+];
 
-export const CREATE_OPTIONS = [
-  ...GATEWAY,
-  ...TASK,
-  ...SUBPROCESS,
+export const ALL_EVENTS = [
   ...NONE_EVENTS,
   ...TYPED_START_EVENTS,
   ...TYPED_NON_INTERRUPTING_START_EVENTS,
   ...TYPED_INTERMEDIATE_EVENT,
-  ...TYPED_END_EVENT,
   ...TYPED_BOUNDARY_EVENT,
+  ...TYPED_END_EVENT
+];
+
+export const CREATE_OPTIONS = [
+  ...TASK,
+  ...GATEWAY,
+  ...SUBPROCESS,
+  ...ALL_EVENTS,
   ...DATA_OBJECTS,
   ...PARTICIPANT
 ];

--- a/lib/util/PopupMenuEntriesUtil.js
+++ b/lib/util/PopupMenuEntriesUtil.js
@@ -1,0 +1,39 @@
+/**
+ * Build flat popup menu entries from a list of create/append options, shared by
+ * the create and append menus.
+ *
+ * The library stays neutral about grouping; consumers may impose their own
+ * structure on top of these entries.
+ *
+ * @param {Array<Object>} options
+ * @param {Object} config
+ * @param {string} config.idPrefix entry id prefix, e.g. `'create'` or `'append'`
+ * @param {Function} config.translate
+ * @param {Function} config.createAction maps an option to its entry `action`
+ * @param {Function} [config.filter] keep predicate for options
+ *
+ * @return {Object} popup menu entries
+ */
+export function buildMenuEntries(options, config) {
+  const entries = {};
+
+  options.forEach(option => {
+    if (!config.filter || config.filter(option)) {
+      entries[`${config.idPrefix}-${option.actionName}`] = toActionEntry(option, config);
+    }
+  });
+
+  return entries;
+}
+
+function toActionEntry(option, { translate, createAction }) {
+  return {
+    label: option.label && translate(option.label),
+    className: option.className,
+    description: option.description && translate(option.description),
+    group: option.group && { ...option.group, name: translate(option.group.name) },
+    search: option.search,
+    rank: option.rank,
+    action: createAction(option)
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/preact": "^3.2.4",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
-        "bpmn-js": "^18.21.0",
+        "bpmn-js": "^18.22.0",
         "bpmn-js-element-templates": "^2.27.0",
         "bpmn-js-properties-panel": "^5.60.0",
         "chai": "^6.2.2",
@@ -43,7 +43,7 @@
         "zeebe-bpmn-moddle": "^1.16.0"
       },
       "peerDependencies": {
-        "diagram-js": ">= 15.18.0"
+        "diagram-js": ">= 15.23.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3099,18 +3099,18 @@
       "dev": true
     },
     "node_modules/bpmn-js": {
-      "version": "18.21.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.21.0.tgz",
-      "integrity": "sha512-TVPsgsTnD24jrcZ5bjU3LAfhEp4UtfnRIQ53Spf7Cs2nMofFU27uZ/Z5MTxNzfB5PVczjZbx7UTRmq+RcCZ7HA==",
+      "version": "18.22.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.22.0.tgz",
+      "integrity": "sha512-hM5aOiyLVdVGA80nveJLXFVQMpsaST7RilErjeKfXMhpZQJTnzU+yLDaenIJsq2f90+9inyktVPqsS1Ersik2A==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.20.0",
-        "diagram-js-direct-editing": "^3.4.0",
+        "diagram-js": "^15.23.0",
+        "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/bpmn-js/node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3944,16 +3944,16 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.20.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.20.0.tgz",
-      "integrity": "sha512-35BxXuzXZm8WSRwtqvWnxmhe0oqtAKHN+i5jK9b1DKo9Ha3CzEsE1r2d9EGfU8zZDrkn++Q1nxSTHRsMEnbpWA==",
+      "version": "15.23.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.0.tgz",
+      "integrity": "sha512-cCgL+4Ep0xrLe6TtdvRVgo6bWYjUbrQg+ES/9rpltqmTD2YaPoC+NYcRsKYw/fDO+1RN0q16NzErP1svVZhNQg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",
@@ -3964,14 +3964,14 @@
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.4.0.tgz",
-      "integrity": "sha512-eXfd+nxJr5xt3YlCrs+E53mPi+gqBWRBkAXkR99ZPL7Pl0B3H5nkv/uiwx4Q4vJU/Sp8Jy3zVdhP/Y2c6loTjw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.1.tgz",
+      "integrity": "sha512-fEQCQ/x5oKVV0m7Nmgv7i85Vhw+kJkKNXF8zcV5Vm0KwF8x/8e3Ax0aJgdXt8/fDPymEkY8HmZweXIipCeeh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0"
       },
       "engines": {
         "node": "*"
@@ -3981,16 +3981,16 @@
       }
     },
     "node_modules/diagram-js-direct-editing/node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/diagram-js/node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "license": "MIT"
     },
     "node_modules/didi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "zeebe-bpmn-moddle": "^1.16.0"
       },
       "peerDependencies": {
+        "bpmn-js": ">= 18.22.0",
         "diagram-js": ">= 15.23.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "module": "dist/index.es.js",
   "peerDependencies": {
-    "diagram-js": ">= 15.18.0"
+    "diagram-js": ">= 15.23.0"
   },
   "devDependencies": {
     "@bpmn-io/element-template-chooser": "^3.0.0",
@@ -52,7 +52,7 @@
     "@testing-library/preact": "^3.2.4",
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
-    "bpmn-js": "^18.21.0",
+    "bpmn-js": "^18.22.0",
     "bpmn-js-element-templates": "^2.27.0",
     "bpmn-js-properties-panel": "^5.60.0",
     "chai": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "module": "dist/index.es.js",
   "peerDependencies": {
+    "bpmn-js": ">= 18.22.0",
     "diagram-js": ">= 15.23.0"
   },
   "devDependencies": {

--- a/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
@@ -67,6 +67,25 @@ describe('features/create-append-anything - append menu provider', function() {
     }));
 
 
+    it('should allow overriding append menu width via css variable', inject(
+      function(elementRegistry, contextPad, canvas) {
+
+        // given
+        const element = elementRegistry.get('StartEvent_1');
+
+        canvas.getContainer().style.setProperty('--bpmn-append-popup-width', '400px');
+
+        contextPad.open(element);
+
+        // when
+        contextPad.trigger('click', padEvent('append'));
+
+        // then
+        expect(getComputedStyle(getPopupMenu()).width).to.eql('400px');
+      }
+    ));
+
+
     it('should hide icon if append is disallowed', inject(
       function(elementRegistry, contextPad, customRules) {
 

--- a/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
+++ b/test/spec/create-append-anything/append-menu/AppendContextPadProvider.spec.js
@@ -52,6 +52,21 @@ describe('features/create-append-anything - append menu provider', function() {
     }));
 
 
+    it('should open append menu with default width', inject(function(elementRegistry, contextPad) {
+
+      // given
+      const element = elementRegistry.get('StartEvent_1');
+
+      contextPad.open(element);
+
+      // when
+      contextPad.trigger('click', padEvent('append'));
+
+      // then
+      expect(getComputedStyle(getPopupMenu()).width).to.eql('300px');
+    }));
+
+
     it('should hide icon if append is disallowed', inject(
       function(elementRegistry, contextPad, customRules) {
 

--- a/test/spec/create-append-anything/create-menu/CreatePaletteProvider.spec.js
+++ b/test/spec/create-append-anything/create-menu/CreatePaletteProvider.spec.js
@@ -50,6 +50,19 @@ describe('features/palette', function() {
       expect(getComputedStyle(getPopupMenu()).width).to.eql('300px');
     }));
 
+
+    it('should allow overriding create menu width via css variable', inject(function(canvas) {
+
+      // given
+      canvas.getContainer().style.setProperty('--bpmn-create-popup-width', '400px');
+
+      // when
+      triggerPaletteEntry('create');
+
+      // then
+      expect(getComputedStyle(getPopupMenu()).width).to.eql('400px');
+    }));
+
   });
 
 });

--- a/test/spec/create-append-anything/create-menu/CreatePaletteProvider.spec.js
+++ b/test/spec/create-append-anything/create-menu/CreatePaletteProvider.spec.js
@@ -7,6 +7,8 @@ import {
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
+import { query as domQuery } from 'min-dom';
+
 import CreateMenuModule from 'lib/create-append-anything/create-menu';
 
 import { createMoveEvent } from 'diagram-js/lib/features/mouse/Mouse';
@@ -38,6 +40,16 @@ describe('features/palette', function() {
       expect(args[1]).to.eq('bpmn-create');
     }));
 
+
+    it('should open create menu with default width', inject(function() {
+
+      // when
+      triggerPaletteEntry('create');
+
+      // then
+      expect(getComputedStyle(getPopupMenu()).width).to.eql('300px');
+    }));
+
   });
 
 });
@@ -53,4 +65,10 @@ function triggerPaletteEntry(id) {
       entry.action.click(createMoveEvent(0, 0));
     }
   });
+}
+
+function getPopupMenu() {
+  const popup = getBpmnJS().get('popupMenu');
+
+  return popup._current && domQuery('.djs-popup', popup._current.container);
 }


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6037

Reuse shared menu entries list and expose it for the further consamption in https://github.com/camunda/camunda-bpmn-js/pull/485. Also allow to style menus width with css variable.


**Try it**:
```
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#create-append-menu-groups
```



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
